### PR TITLE
[HF] MPT-3240 Check tab definition only if it exists in Excel, otherwise skip it

### DIFF
--- a/swo/mpt/cli/core/products/constants.py
+++ b/swo/mpt/cli/core/products/constants.py
@@ -15,7 +15,7 @@ TAB_SUBSCRIPTION_PARAMETERS = "Subscription Parameters"
 TAB_ITEMS = "Items"
 TAB_TEMPLATES = "Templates"
 TAB_SETTINGS = "Settings"
-REQUIRED_TABS = [
+ALL_TABS = [
     TAB_GENERAL,
     TAB_PARAMETERS_GROUPS,
     TAB_ITEMS_GROUPS,
@@ -27,6 +27,11 @@ REQUIRED_TABS = [
     TAB_TEMPLATES,
     TAB_SETTINGS,
 ]
+REQUIRED_TABS = [
+    TAB_GENERAL,
+    TAB_SETTINGS,
+]
+
 
 # General tab definition
 GENERAL_PRODUCT_ID = "Product ID"

--- a/swo/mpt/cli/core/products/flows.py
+++ b/swo/mpt/cli/core/products/flows.py
@@ -112,7 +112,7 @@ def check_product_definition(
         if sheet_name not in wb.sheetnames:
             stats.add_msg(sheet_name, "", "Required tab doesn't exist")
 
-    existing_sheets = set(constants.REQUIRED_TABS).intersection(set(wb.sheetnames))
+    existing_sheets = set(constants.ALL_TABS).intersection(set(wb.sheetnames))
 
     for sheet_name in existing_sheets:
         if sheet_name not in constants.REQUIRED_FIELDS_BY_TAB:

--- a/tests/test_swo/test_mpt/test_cli/test_core/test_products/test_flows.py
+++ b/tests/test_swo/test_mpt/test_cli/test_core/test_products/test_flows.py
@@ -63,14 +63,6 @@ def test_check_product_definition_not_all_tabs(empty_file):
     stats = check_product_definition(empty_file, stats)
 
     expected_message = """General: Required tab doesn't exist
-Parameters Groups: Required tab doesn't exist
-Items Groups: Required tab doesn't exist
-Agreements Parameters: Required tab doesn't exist
-Item Parameters: Required tab doesn't exist
-Request Parameters: Required tab doesn't exist
-Subscription Parameters: Required tab doesn't exist
-Items: Required tab doesn't exist
-Templates: Required tab doesn't exist
 Settings: Required tab doesn't exist\n"""
 
     assert not stats.is_empty()


### PR DESCRIPTION
…kip it.

Now there are only 2 required tabs - General and Settings