### PR TITLE
MPT-11142: prepare the code to add product services

### DIFF
--- a/swo/mpt/cli/core/handlers/excel_styles.py
+++ b/swo/mpt/cli/core/handlers/excel_styles.py
@@ -6,10 +6,10 @@ general_tab_title_style.font = Font(color="FFFFFF", bold=True)
 general_tab_title_style.alignment = Alignment(horizontal="center", vertical="center")
 
 
-price_items_tab_style = NamedStyle(name="price_items_tab_style")
-price_items_tab_style.fill = PatternFill(fill_type="solid", fgColor="FF757171")
-price_items_tab_style.font = Font(color="FFFFFF", bold=True)
-price_items_tab_style.alignment = Alignment(horizontal="center", vertical="center")
+horizontal_tab_style = NamedStyle(name="price_items_tab_style")
+horizontal_tab_style.fill = PatternFill(fill_type="solid", fgColor="FF757171")
+horizontal_tab_style.font = Font(color="FFFFFF", bold=True)
+horizontal_tab_style.alignment = Alignment(horizontal="center", vertical="center")
 
 number_format_style = NamedStyle(name="number_format_style")
 

--- a/swo/mpt/cli/core/mpt/api.py
+++ b/swo/mpt/cli/core/mpt/api.py
@@ -59,8 +59,9 @@ class APIService(Generic[APIModel]):
         return {"meta": meta.model_dump(), "data": json_body["data"]}
 
     @wrap_http_error
-    def post(self, data: dict[str, Any]) -> dict[str, Any]:
-        response = self.client.post(self.url, json=data)
+    def post(self, data: dict[str, Any], headers: dict[str, Any] | None = None) -> dict[str, Any]:
+        headers = headers or {}
+        response = self.client.post(self.url, json=data, headers=headers)
         response.raise_for_status()
         return self.api_model.model_validate(response.json()).model_dump()
 

--- a/swo/mpt/cli/core/mpt/models.py
+++ b/swo/mpt/cli/core/mpt/models.py
@@ -34,6 +34,10 @@ class Product(BaseModel):
 
 class ParameterGroup(BaseModel):
     id: str
+    default: bool
+    description: str
+    display_order: int
+    label: str
     name: str
 
 

--- a/swo/mpt/cli/core/price_lists/handlers/price_list_excel_file_manager.py
+++ b/swo/mpt/cli/core/price_lists/handlers/price_list_excel_file_manager.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from swo.mpt.cli.core.handlers.excel_styles import general_tab_title_style
 from swo.mpt.cli.core.handlers.file_manager import ExcelFileManager
 from swo.mpt.cli.core.price_lists.constants import (
     ERROR_COLUMN_NAME,
@@ -7,7 +8,6 @@ from swo.mpt.cli.core.price_lists.constants import (
     GENERAL_PRICELIST_ID,
     TAB_GENERAL,
 )
-from swo.mpt.cli.core.price_lists.handlers.excel_styles import general_tab_title_style
 from swo.mpt.cli.core.price_lists.models import PriceListData
 
 

--- a/swo/mpt/cli/core/price_lists/handlers/price_list_item_excel_file_manager.py
+++ b/swo/mpt/cli/core/price_lists/handlers/price_list_item_excel_file_manager.py
@@ -1,6 +1,7 @@
 from collections.abc import Generator
 
 from openpyxl.worksheet.datavalidation import DataValidation
+from swo.mpt.cli.core.handlers.excel_styles import get_number_format_style, horizontal_tab_style
 from swo.mpt.cli.core.handlers.file_manager import ExcelFileManager
 from swo.mpt.cli.core.price_lists.constants import (
     ERROR_COLUMN_NAME,
@@ -8,10 +9,6 @@ from swo.mpt.cli.core.price_lists.constants import (
     PRICELIST_ITEMS_FIELDS,
     PRICELIST_ITEMS_ID,
     TAB_PRICE_ITEMS,
-)
-from swo.mpt.cli.core.price_lists.handlers.excel_styles import (
-    get_number_format_style,
-    price_items_tab_style,
 )
 from swo.mpt.cli.core.price_lists.models import ItemData
 
@@ -59,7 +56,7 @@ class PriceListItemExcelFileManager(ExcelFileManager):
                 row=1,
                 col=col,
                 value=field,
-                style=price_items_tab_style,
+                style=horizontal_tab_style,
             )
 
     def read_items_data(self) -> Generator[ItemData, None, None]:

--- a/swo/mpt/cli/core/price_lists/services/price_list_service.py
+++ b/swo/mpt/cli/core/price_lists/services/price_list_service.py
@@ -75,7 +75,7 @@ class PriceListService(BaseService):
         Retrieves a price list from the API using its resource ID.
 
         Args:
-            resource_id (str): The ID of the price list to retrieve.
+            resource_id: The ID of the price list to retrieve.
 
         Returns:
             ServiceResult: The result of the retrieval operation.
@@ -93,7 +93,7 @@ class PriceListService(BaseService):
         Updates an existing price list by sending the modified general data to the API.
 
         Args:
-            resource_id (str): The ID of the price list to update.
+            resource_id: The ID of the price list to update.
 
         Returns:
             ServiceResult: The result of the update operation.

--- a/swo/mpt/cli/core/products/models/__init__.py
+++ b/swo/mpt/cli/core/products/models/__init__.py
@@ -1,14 +1,16 @@
-from .items import ItemData, ItemGroupData
-from .parameters import ParameterGroupData, ParametersData
-from .product import ProductData, SettingData
+from .item_group import ItemGroupData
+from .items import ItemData
+from .parameter_group import ParameterGroupData
+from .parameters import ParametersData
+from .product import ProductData, SettingsData
 from .template import TemplateData
 
 __all__ = [
-    "ItemGroupData",
     "ItemData",
-    "ParameterGroupData",
+    "ItemGroupData",
     "ParametersData",
+    "ParameterGroupData",
     "ProductData",
-    "SettingData",
+    "SettingsData",
     "TemplateData",
 ]

--- a/swo/mpt/cli/core/products/models/data_actions.py
+++ b/swo/mpt/cli/core/products/models/data_actions.py
@@ -1,0 +1,8 @@
+from enum import StrEnum
+
+
+class DataAction(StrEnum):
+    CREATE = "create"
+    DELETE = "delete"
+    UPDATE = "update"
+    SKIP = "-"

--- a/swo/mpt/cli/core/products/models/item_group.py
+++ b/swo/mpt/cli/core/products/models/item_group.py
@@ -1,0 +1,81 @@
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Self
+
+from dateutil import parser
+from swo.mpt.cli.core.models import BaseDataModel
+from swo.mpt.cli.core.products import constants
+from swo.mpt.cli.core.products.models.data_actions import DataAction
+
+
+@dataclass
+class ItemGroupData(BaseDataModel):
+    id: str
+    default: bool
+    description: str
+    display_order: str
+    label: str
+    multiple: bool
+    name: str
+    required: bool
+
+    action: DataAction = DataAction.SKIP
+    coordinate: str | None = None
+    created_date: date | None = None
+    updated_date: date | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Self:
+        return cls(
+            id=data[constants.ITEMS_GROUPS_ID]["value"],
+            coordinate=data[constants.ITEMS_GROUPS_ID]["coordinate"],
+            name=data[constants.ITEMS_GROUPS_NAME]["value"],
+            label=data[constants.ITEMS_GROUPS_LABEL]["value"],
+            description=data[constants.ITEMS_GROUPS_DESCRIPTION]["value"],
+            display_order=data[constants.ITEMS_GROUPS_DISPLAY_ORDER]["value"],
+            default=data[constants.ITEMS_GROUPS_DEFAULT]["value"] == "True",
+            multiple=data[constants.ITEMS_GROUPS_MULTIPLE_CHOICES]["value"] == "True",
+            required=data[constants.ITEMS_GROUPS_REQUIRED]["value"] == "True",
+        )
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> Self:
+        return cls(
+            id=data["id"],
+            coordinate=data[constants.ITEMS_GROUPS_ID]["coordinate"],
+            name=data[constants.ITEMS_GROUPS_NAME]["value"],
+            label=data[constants.ITEMS_GROUPS_LABEL]["value"],
+            description=data[constants.ITEMS_GROUPS_DESCRIPTION]["value"],
+            display_order=data[constants.ITEMS_GROUPS_DISPLAY_ORDER]["value"],
+            default=data[constants.ITEMS_GROUPS_DEFAULT]["value"] == "True",
+            multiple=data[constants.ITEMS_GROUPS_MULTIPLE_CHOICES]["value"] == "True",
+            required=data[constants.ITEMS_GROUPS_REQUIRED]["value"] == "True",
+            created_date=parser.parse(data["audit"]["created"]["at"]).date(),
+            updated_date=parser.parse(data["audit"]["updated"]["at"]).date(),
+        )
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "label": self.label,
+            "description": self.description,
+            "displayOrder": self.display_order,
+            "default": self.default,
+            "multiple": self.multiple,
+            "required": self.required,
+        }
+
+    def to_xlsx(self) -> dict[str, Any]:
+        return {
+            constants.ITEMS_GROUPS_ID: self.id,
+            constants.ITEMS_GROUPS_NAME: self.name,
+            constants.ITEMS_GROUPS_ACTION: self.action,
+            constants.ITEMS_GROUPS_LABEL: self.label,
+            constants.ITEMS_GROUPS_DISPLAY_ORDER: self.display_order,
+            constants.ITEMS_GROUPS_DESCRIPTION: self.description,
+            constants.ITEMS_GROUPS_DEFAULT: self.default,
+            constants.ITEMS_GROUPS_MULTIPLE_CHOICES: self.multiple,
+            constants.ITEMS_GROUPS_REQUIRED: self.required,
+            constants.ITEMS_GROUPS_CREATED: self.created_date,
+            constants.ITEMS_GROUPS_MODIFIED: self.updated_date,
+        }

--- a/swo/mpt/cli/core/products/models/items.py
+++ b/swo/mpt/cli/core/products/models/items.py
@@ -1,27 +1,51 @@
 from dataclasses import dataclass, field
+from datetime import date
+from enum import StrEnum
 from typing import Any, Self
 
+from dateutil import parser
 from swo.mpt.cli.core.models import BaseDataModel
 from swo.mpt.cli.core.products import constants
+
+
+class ItemAction(StrEnum):
+    CREATE = "create"
+    UPDATE = "update"
+    REVIEW = "review"
+    PUBLISH = "publish"
+    UNPUBLISH = "unpublish"
+    SKIP = "-"
 
 
 @dataclass
 class ItemData(BaseDataModel):
     id: str
-    coordinate: str
-    name: str
+    commitment: str
     description: str
     group_id: str
-    group_coordinate: str
+    name: str
+    period: str
     product_id: str
     quantity_not_applicable: bool
     unit_id: str
-    unit_coordinate: str
-    period: str
-    item_type: str
-    external_ids: str
-    commitment: str
+    vendor_id: str
+
+    action: ItemAction = ItemAction.SKIP
+    coordinate: str | None = None
+    group_coordinate: str | None = None
+    group_name: str | None = None
+    item_type: str | None = None
+    operations_id: str | None = None
     parameters: list[dict[str, Any]] = field(default_factory=list)
+    status: str | None = None
+    unit_coordinate: str | None = None
+    unit_name: str | None = None
+    created_date: date | None = None
+    updated_date: date | None = None
+
+    @property
+    def external_ids(self):
+        return self.operations_id if self.item_type == "operations" else self.vendor_id
 
     @property
     def group(self) -> dict[str, Any]:
@@ -45,13 +69,6 @@ class ItemData(BaseDataModel):
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Self:
-        if data.get("is_operations", False):
-            item_type = "operations"
-            external_ids = data[constants.ITEMS_ERP_ITEM_ID]["value"]
-        else:
-            item_type = "vendor"
-            external_ids = data[constants.ITEMS_VENDOR_ITEM_ID]["value"]
-
         try:
             group_id = data["group_id"]
         except KeyError:
@@ -59,20 +76,49 @@ class ItemData(BaseDataModel):
 
         return cls(
             id=data[constants.ITEMS_ID]["value"],
+            action=data[constants.ITEMS_ACTION]["value"],
             coordinate=data[constants.ITEMS_ID]["coordinate"],
-            name=data[constants.ITEMS_NAME]["value"],
+            commitment=data[constants.ITEMS_COMMITMENT_TERM]["value"],
             description=data[constants.ITEMS_DESCRIPTION]["value"],
             group_id=group_id,
             group_coordinate=data[constants.ITEMS_GROUP_ID]["coordinate"],
+            item_type="operations" if data.get("is_operations", False) else "vendor",
+            name=data[constants.ITEMS_NAME]["value"],
+            period=data[constants.ITEMS_BILLING_FREQUENCY]["value"],
             product_id=data["product_id"],
             quantity_not_applicable=data[constants.ITEMS_QUANTITY_APPLICABLE]["value"] == "True",
-            unit_id=data[constants.ITEMS_UNIT_ID]["value"],
+            unit_name=data[constants.ITEMS_UNIT_NAME]["value"],
             unit_coordinate=data[constants.ITEMS_UNIT_ID]["coordinate"],
+            vendor_id=data[constants.ITEMS_VENDOR_ITEM_ID]["value"],
+            group_name=data.get(constants.ITEMS_GROUP_NAME, {}).get("value"),
+            operations_id=data.get(constants.ITEMS_ERP_ITEM_ID, {}).get("value"),
             parameters=data.get("parameters", []),
-            period=data[constants.ITEMS_BILLING_FREQUENCY]["value"],
-            commitment=data.get(constants.ITEMS_COMMITMENT_TERM, {}).get("value"),
-            item_type=item_type,
-            external_ids=external_ids,
+            unit_id=data.get(constants.ITEMS_UNIT_ID, {}).get("value"),
+            created_date=data.get(constants.ITEMS_CREATED, {}).get("value"),
+            updated_date=data.get(constants.ITEMS_MODIFIED, {}).get("value"),
+        )
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> Self:
+        updated = data["audit"].get("updated", {}).get("at")
+        return cls(
+            id=data["id"],
+            commitment=data["commitment"],
+            description=data["description"],
+            group_id=data["group"]["id"],
+            name=data["name"],
+            period=data["terms"]["period"],
+            product_id=data["product"]["id"],
+            quantity_not_applicable=data["quantityNotApplicable"],
+            unit_id=data["unit"]["id"],
+            vendor_id=data["externalIds"]["vendor"],
+            group_name=data["group"]["name"],
+            operations_id=data["operations"]["id"],
+            parameters=[],
+            status=data["status"],
+            unit_name=data["unit"]["name"],
+            created_date=parser.parse(data["audit"]["created"]["at"]).date(),
+            updated_date=updated and parser.parse(updated).date() or None,
         )
 
     def to_json(self) -> dict[str, Any]:
@@ -88,40 +134,22 @@ class ItemData(BaseDataModel):
             "parameters": self.parameters,
         }
 
-
-@dataclass
-class ItemGroupData(BaseDataModel):
-    id: str
-    coordinate: str
-    name: str
-    label: str
-    description: str
-    display_order: str
-    default: bool
-    multiple: bool
-    required: bool
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> Self:
-        return cls(
-            id=data[constants.ITEMS_GROUPS_ID]["value"],
-            coordinate=data[constants.ITEMS_GROUPS_ID]["coordinate"],
-            name=data[constants.ITEMS_GROUPS_NAME]["value"],
-            label=data[constants.ITEMS_GROUPS_LABEL]["value"],
-            description=data[constants.ITEMS_GROUPS_DESCRIPTION]["value"],
-            display_order=data[constants.ITEMS_GROUPS_DISPLAY_ORDER]["value"],
-            default=data[constants.ITEMS_GROUPS_DEFAULT]["value"] == "True",
-            multiple=data[constants.ITEMS_GROUPS_MULTIPLE_CHOICES]["value"] == "True",
-            required=data[constants.ITEMS_GROUPS_REQUIRED]["value"] == "True",
-        )
-
-    def to_json(self) -> dict[str, Any]:
+    def to_xlsx(self) -> dict[str, Any]:
         return {
-            "name": self.name,
-            "label": self.label,
-            "description": self.description,
-            "displayOrder": self.display_order,
-            "default": self.default,
-            "multiple": self.multiple,
-            "required": self.required,
+            constants.ITEMS_ID: self.id,
+            constants.ITEMS_NAME: self.name,
+            constants.ITEMS_ACTION: self.action,
+            constants.ITEMS_VENDOR_ITEM_ID: "",
+            constants.ITEMS_ERP_ITEM_ID: "",
+            constants.ITEMS_DESCRIPTION: self.description,
+            constants.ITEMS_BILLING_FREQUENCY: self.period,
+            constants.ITEMS_COMMITMENT_TERM: self.commitment,
+            constants.ITEMS_STATUS: self.status,
+            constants.ITEMS_GROUPS_ID: self.group_id,
+            constants.ITEMS_GROUPS_NAME: self.group_name,
+            constants.ITEMS_UNIT_ID: self.unit_id,
+            constants.ITEMS_UNIT_NAME: self.unit_name,
+            constants.ITEMS_QUANTITY_APPLICABLE: self.quantity_not_applicable,
+            constants.ITEMS_CREATED: self.created_date,
+            constants.ITEMS_MODIFIED: self.updated_date,
         }

--- a/swo/mpt/cli/core/products/models/parameter_group.py
+++ b/swo/mpt/cli/core/products/models/parameter_group.py
@@ -1,0 +1,74 @@
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Self
+
+from dateutil import parser
+from swo.mpt.cli.core.models import BaseDataModel
+from swo.mpt.cli.core.products import constants
+from swo.mpt.cli.core.products.models.data_actions import DataAction
+
+
+@dataclass
+class ParameterGroupData(BaseDataModel):
+    id: str
+    default: bool
+    description: str
+    display_order: int
+    label: str
+    name: str
+
+    action: DataAction = DataAction.SKIP
+    coordinate: str | None = None
+    created_date: date | None = None
+    updated_date: date | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Self:
+        created_date = data[constants.PARAMETERS_GROUPS_CREATED].get("value")
+        updated_date = data[constants.PARAMETERS_GROUPS_MODIFIED].get("value")
+        return cls(
+            id=data[constants.PARAMETERS_GROUPS_ID]["value"],
+            coordinate=data[constants.PARAMETERS_GROUPS_ID]["coordinate"],
+            default=data[constants.PARAMETERS_GROUPS_DEFAULT]["value"] == "True",
+            description=data[constants.PARAMETERS_GROUPS_DESCRIPTION]["value"],
+            display_order=data[constants.PARAMETERS_GROUPS_DISPLAY_ORDER]["value"],
+            label=data[constants.PARAMETERS_GROUPS_LABEL]["value"],
+            name=data[constants.PARAMETERS_GROUPS_NAME]["value"],
+            created_date=created_date.date() if created_date else None,
+            updated_date=updated_date.date() if updated_date else None,
+        )
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> Self:
+        return cls(
+            id=data["id"],
+            description=data["description"],
+            default=data["default"],
+            display_order=data["displayOrder"],
+            label=data["label"],
+            name=data["name"],
+            created_date=parser.parse(data["audit"]["created"]["at"]).date(),
+            updated_date=parser.parse(data["audit"]["updated"]["at"]).date(),
+        )
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "default": self.default,
+            "description": self.description,
+            "displayOrder": self.display_order,
+            "label": self.label,
+            "name": self.name,
+        }
+
+    def to_xlsx(self) -> dict[str, Any]:
+        return {
+            constants.PARAMETERS_GROUPS_ID: self.id,
+            constants.PARAMETERS_GROUPS_NAME: self.name,
+            constants.PARAMETERS_GROUPS_ACTION: self.action,
+            constants.PARAMETERS_GROUPS_LABEL: self.label,
+            constants.PARAMETERS_GROUPS_DISPLAY_ORDER: self.display_order,
+            constants.PARAMETERS_GROUPS_DESCRIPTION: self.description,
+            constants.PARAMETERS_GROUPS_DEFAULT: self.default,
+            constants.PARAMETERS_GROUPS_CREATED: self.created_date,
+            constants.PARAMETERS_GROUPS_MODIFIED: self.updated_date,
+        }

--- a/swo/mpt/cli/core/products/models/parameters.py
+++ b/swo/mpt/cli/core/products/models/parameters.py
@@ -7,39 +7,6 @@ from swo.mpt.cli.core.models import BaseDataModel
 from swo.mpt.cli.core.products import constants
 
 
-@dataclass
-class ParameterGroupData(BaseDataModel):
-    id: str
-
-    name: str
-    coordinate: str | None = None
-    label: str | None = None
-    description: str | None = None
-    displayOrder: str | None = None
-    default: bool | None = None
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> Self:
-        return cls(
-            id=data[constants.PARAMETERS_GROUPS_ID]["value"],
-            coordinate=data[constants.PARAMETERS_GROUPS_ID]["coordinate"],
-            name=data[constants.PARAMETERS_GROUPS_NAME]["value"],
-            label=data[constants.PARAMETERS_GROUPS_LABEL]["value"],
-            description=data[constants.PARAMETERS_GROUPS_DESCRIPTION]["value"],
-            displayOrder=data[constants.PARAMETERS_GROUPS_DISPLAY_ORDER]["value"],
-            default=data[constants.PARAMETERS_GROUPS_DEFAULT]["value"] == "True",
-        )
-
-    def to_json(self) -> dict[str, Any]:
-        return {
-            "name": self.name,
-            "label": self.label,
-            "description": self.description,
-            "displayOrder": self.displayOrder,
-            "default": self.default,
-        }
-
-
 class ScopeEnum(StrEnum):
     AGREEMENT = "Agreement"
     ITEM = "Item"

--- a/swo/mpt/cli/core/products/models/product.py
+++ b/swo/mpt/cli/core/products/models/product.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, Self, TypeAlias, TypedDict
+from typing import Any, Self, TypedDict
 
 from swo.mpt.cli.core.models.data_model import BaseDataModel
 from swo.mpt.cli.core.products import constants
@@ -12,12 +12,9 @@ class SettingItem(TypedDict):
     coordinate: str
 
 
-SettingData: TypeAlias = SettingItem
-
-
 @dataclass
 class SettingsData(BaseDataModel):
-    items: list[SettingData] = field(default_factory=list)
+    items: list[SettingItem] = field(default_factory=list)
     json_path: str | None = None
 
     @classmethod
@@ -62,9 +59,6 @@ class ProductData(BaseDataModel):
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Self:
-        settings = (
-            SettingsData.from_dict(data["settings"]) if "settings" in data else SettingsData()
-        )
         return cls(
             id=data[constants.GENERAL_PRODUCT_ID]["value"],
             coordinate=data[constants.GENERAL_PRODUCT_ID]["coordinate"],
@@ -72,7 +66,7 @@ class ProductData(BaseDataModel):
             short_description=data[constants.GENERAL_CATALOG_DESCRIPTION]["value"],
             long_description=data[constants.GENERAL_PRODUCT_DESCRIPTION]["value"],
             website=data[constants.GENERAL_PRODUCT_WEBSITE]["value"],
-            settings=settings,
+            settings=SettingsData.from_dict(data["settings"]),
         )
 
     def to_json(self) -> dict[str, Any]:

--- a/swo/mpt/cli/core/stats.py
+++ b/swo/mpt/cli/core/stats.py
@@ -65,6 +65,7 @@ class ErrorMessagesCollector:
 
 class StatsCollector(ABC):
     __id: str | None = None
+    errors = ErrorMessagesCollector()
 
     def __init__(self, tabs: dict[str, Results]) -> None:
         self.__has_error = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,6 +113,10 @@ def mpt_product():
 def mpt_parameter_group():
     return {
         "id": "PRG-1234-1234",
+        "default": False,
+        "description": "Default parameter group",
+        "display_order": 100,
+        "label": "Parameters",
         "name": "Parameter Group 1",
     }
 
@@ -170,7 +174,14 @@ def product():
 
 @pytest.fixture
 def parameter_group():
-    return ParameterGroup(id="PRG-1234-1234", name="Parameter Group")
+    return ParameterGroup(
+        id="PRG-1234-1234",
+        default=False,
+        description="Default parameter group",
+        display_order=100,
+        label="Parameters",
+        name="Parameter Group",
+    )
 
 
 @pytest.fixture

--- a/tests/test_swo/test_mpt/test_cli/test_core/test_mpt/test_api.py
+++ b/tests/test_swo/test_mpt/test_cli/test_core/test_mpt/test_api.py
@@ -90,7 +90,7 @@ def test_post(mocker, service):
     result = service.post({"name": "test"})
 
     assert result == {"id": "fakeId", "name": "test"}
-    client_mock.assert_called_once_with("fake_url/", json={"name": "test"})
+    client_mock.assert_called_once_with("fake_url/", json={"name": "test"}, headers={})
 
 
 def test_update_success(mocker, service):


### PR DESCRIPTION
We are refactoring the current product flows by adopting the services approach, similar to what we've done with the price list. This requires several changes, so we’ll split them across multiple PRs to make the review process easier.

### Changes

- Move the excel styles from price lists to core so they can be used by product file managers
- Update data model fields to comply with the requirements from our xlsx file templates
- Add headers to the API post method to enable multipart request


### Next steps

- Add services and related components to update products
- Add services related components to create products (including just products and items)
- Add services and related components for product-related tasks, such as parameters, parameter groups, agreements, ... for creating and updating
- Implement export functionality