### PR TITLE
MPT-11142: migrate product creation flow to use product service

### DIFF
--- a/tests/audit_plugin/test_app.py
+++ b/tests/audit_plugin/test_app.py
@@ -1,25 +1,10 @@
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 from swo.mpt.cli.plugins.audit_plugin.app import app, compare_audit_trails
 from typer.testing import CliRunner
 
 runner = CliRunner()
-
-
-@pytest.fixture
-def mock_client():
-    return Mock()
-
-
-@pytest.fixture
-def mock_get_active_account():
-    return Mock()
-
-
-@pytest.fixture
-def mock_client_from_account():
-    return Mock()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,9 @@ from swo.mpt.cli.core.mpt.models import (
     Template,
     Uom,
 )
+from swo.mpt.cli.core.products.services import ProductService
+from swo.mpt.cli.core.services.service_result import ServiceResult
+from swo.mpt.cli.core.stats import ProductStatsCollector
 
 
 @pytest.fixture
@@ -366,7 +369,7 @@ def mock_sync_product(
     item,
     uom,
     template,
-    product,
+    product_data_from_json,
 ):
     mocker.patch(
         "swo.mpt.cli.core.products.flows.create_parameter_group", return_value=parameter_group
@@ -388,4 +391,9 @@ def mock_sync_product(
     mocker.patch("swo.mpt.cli.core.products.flows.mpt_create_item", return_value=item)
     mocker.patch("swo.mpt.cli.core.products.flows.search_uom_by_name", return_value=uom)
     mocker.patch("swo.mpt.cli.core.products.flows.create_template", return_value=template)
-    mocker.patch("swo.mpt.cli.core.products.flows.create_product", return_value=product)
+    stats = ProductStatsCollector()
+    mocker.patch.object(
+        ProductService,
+        "create",
+        return_value=ServiceResult(success=True, model=product_data_from_json, stats=stats),
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,8 +11,6 @@ from swo.mpt.cli.core.mpt.models import (
     ItemGroup,
     Parameter,
     ParameterGroup,
-    PriceList,
-    PriceListItem,
     Product,
     Template,
     Uom,
@@ -96,20 +94,6 @@ def mpt_products():
             },
         },
     ]
-
-
-@pytest.fixture
-def mpt_product():
-    return {
-        "id": "PRD-1234-1234",
-        "name": "Adobe for Commercial",
-        "status": "Published",
-        "vendor": {
-            "id": "ACC-4321",
-            "name": "Adobe",
-            "type": "Vendor",
-        },
-    }
 
 
 @pytest.fixture
@@ -215,21 +199,6 @@ def uom():
 @pytest.fixture
 def template():
     return Template(id="TPL-0000-0000-0001", name="Template")
-
-
-@pytest.fixture
-def price_list():
-    return PriceList(id="PRC-1234-1234")
-
-
-@pytest.fixture
-def price_list_item(item):
-    return PriceListItem(id="PRI-1234-1234", item=item)
-
-
-@pytest.fixture
-def product_icon_path():
-    return Path("swo/mpt/cli/core/icons/fake-icon.png")
 
 
 @pytest.fixture

--- a/tests/test_swo/test_mpt/test_cli/test_core/test_handlers/test_file_handler.py
+++ b/tests/test_swo/test_mpt/test_cli/test_core/test_handlers/test_file_handler.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-import pytest
 from swo.mpt.cli.core.handlers import FileHandler
 
 
@@ -15,7 +14,6 @@ class FakeFileHandler(FileHandler):
         pass
 
 
-@pytest.fixture
 def test_exists_file_returns_true(mocker):
     mocker.patch("os.path.exists", return_value=True)
 
@@ -24,7 +22,6 @@ def test_exists_file_returns_true(mocker):
     assert file_handler.exists() is True
 
 
-@pytest.fixture
 def test_exists_file_returns_false(mocker):
     mocker.patch("os.path.exists", return_value=False)
 

--- a/tests/test_swo/test_mpt/test_cli/test_core/test_mpt/test_flows.py
+++ b/tests/test_swo/test_mpt/test_cli/test_core/test_mpt/test_flows.py
@@ -8,7 +8,6 @@ from swo.mpt.cli.core.mpt.flows import (
     create_item_group,
     create_parameter,
     create_parameter_group,
-    create_product,
     create_template,
     get_products,
     get_token,
@@ -99,34 +98,6 @@ def test_get_products_exception(requests_mocker, mpt_client):
 
     with pytest.raises(MPTAPIError) as e:
         get_products(mpt_client, 10, 0)
-
-    assert "Internal Server Error" in str(e.value)
-
-
-def test_create_product(requests_mocker, mpt_client, mpt_product, product_icon_path):
-    requests_mocker.post(urljoin(mpt_client.base_url, "/catalog/products"), json=mpt_product)
-    requests_mocker.put(
-        urljoin(mpt_client.base_url, f"/catalog/products/{mpt_product['id']}/settings"),
-        match=[matchers.json_params_matcher({"settings": "1234"})],
-    )
-
-    product = create_product(
-        mpt_client, {"name": "Create product"}, {"settings": "1234"}, product_icon_path
-    )
-
-    assert product == Product.model_validate(mpt_product)
-
-
-def test_create_product_exception(requests_mocker, mpt_client, mpt_product, product_icon_path):
-    requests_mocker.post(urljoin(mpt_client.base_url, "/catalog/products"), status=500)
-
-    with pytest.raises(MPTAPIError) as e:
-        create_product(
-            mpt_client,
-            {"name": "Create product"},
-            {"settings": "1234"},
-            product_icon_path,
-        )
 
     assert "Internal Server Error" in str(e.value)
 


### PR DESCRIPTION
After adding the product services, the create product flow in sync app command have been replaced by product service methods.

### Next steps

* Add services related components to create items
* Add services and related components for product-related tasks, such as parameters, parameter groups, agreements, ... for creating and updating
* Implement export functionality