### PR TITLE
MPT-316: Add related base service for related components

### DIFF
--- a/swo/mpt/cli/core/price_lists/app.py
+++ b/swo/mpt/cli/core/price_lists/app.py
@@ -151,9 +151,7 @@ def export(
             file_manager=PriceListExcelFileManager(str(file_path)),
             stats=stats,
         )
-        result = PriceListService(price_list_service_context).export(
-            context={"price_list_id": price_list_id}
-        )
+        result = PriceListService(price_list_service_context).export(resource_id=price_list_id)
         if not result.success:
             console.print(f"Failed to export price list with id: {price_list_id}")
             console.print(result.errors)
@@ -167,7 +165,7 @@ def export(
             file_manager=PriceListItemExcelFileManager(str(file_path)),
             stats=stats,
         )
-        result = ItemService(item_service_context).export(context={"price_list": result.model})
+        result = ItemService(item_service_context).export()
         if not result.success:
             console.print(f"Failed to export price list items for id: {price_list_id}")
             has_error = True

--- a/swo/mpt/cli/core/price_lists/models/item.py
+++ b/swo/mpt/cli/core/price_lists/models/item.py
@@ -43,10 +43,12 @@ class ItemData(BaseDataModel):
 
     action: ItemAction = ItemAction.SKIP
     coordinate: str | None = None
+    currency: str | None = None
     lp_x1: float | None = None
     lp_xm: float | None = None
     lp_xy: float | None = None
     modified_date: date | None = None
+    precision: int | None = None
     pp_x1: float | None = None
     pp_xm: float | None = None
     pp_xy: float | None = None
@@ -90,6 +92,7 @@ class ItemData(BaseDataModel):
         return cls(
             id=data.get("id", ""),
             billing_frequency=data["item"]["terms"]["period"],
+            currency=data["priceList"]["currency"],
             commitment=data["item"]["terms"].get("commitment"),
             erp_id=data["item"]["externalIds"].get("operations"),
             item_id=data["item"]["id"],
@@ -98,6 +101,7 @@ class ItemData(BaseDataModel):
             lp_xm=data.get("LPxM"),
             lp_xy=data.get("LPxY"),
             markup=data.get("markup"),
+            precision=data["priceList"]["precision"],
             pp_x1=data.get("PPx1"),
             pp_xm=data.get("PPxM"),
             pp_xy=data.get("PPxY"),

--- a/swo/mpt/cli/core/price_lists/services/price_list_service.py
+++ b/swo/mpt/cli/core/price_lists/services/price_list_service.py
@@ -1,7 +1,5 @@
-from typing import Any
-
 from swo.mpt.cli.core.errors import MPTAPIError
-from swo.mpt.cli.core.services.base_service import BaseService
+from swo.mpt.cli.core.services import BaseService
 from swo.mpt.cli.core.services.service_result import ServiceResult
 
 
@@ -27,19 +25,8 @@ class PriceListService(BaseService):
 
         return ServiceResult(success=True, model=price_list, stats=self.stats)
 
-    def export(self, context: dict[str, Any]) -> ServiceResult:
-        """
-        Exports a price list by retrieving it from the API and writing its data to a
-        new tab in a file.
-
-        Args:
-            context: A dictionary containing the price_list_id to export.
-
-        Returns:
-            ServiceResult: The result of the export operation.
-        """
-        price_list_id = context["price_list_id"]
-        result = self.retrieve_from_mpt(price_list_id)
+    def export(self, resource_id: str) -> ServiceResult:
+        result = self.retrieve_from_mpt(resource_id)
         price_list = result.model
         if not result.success or not price_list:
             return result

--- a/swo/mpt/cli/core/products/services/item_service.py
+++ b/swo/mpt/cli/core/products/services/item_service.py
@@ -1,11 +1,9 @@
-from typing import Any
-
 from swo.mpt.cli.core.errors import MPTAPIError
 from swo.mpt.cli.core.models import DataCollectionModel
 from swo.mpt.cli.core.mpt.flows import search_uom_by_name
 from swo.mpt.cli.core.products.constants import TAB_ITEMS
 from swo.mpt.cli.core.products.models import ItemData
-from swo.mpt.cli.core.services.base_service import BaseService
+from swo.mpt.cli.core.services import BaseService
 from swo.mpt.cli.core.services.service_result import ServiceResult
 
 
@@ -30,7 +28,7 @@ class ItemService(BaseService):
 
         return ServiceResult(success=len(errors) == 0, errors=errors, model=None, stats=self.stats)
 
-    def export(self, context: dict[str, Any]) -> ServiceResult:  # pragma: no cover
+    def export(self, resource_id: str) -> ServiceResult:  # pragma: no cover
         return ServiceResult(
             success=False, errors=["Export method not implemented"], model=None, stats=self.stats
         )

--- a/swo/mpt/cli/core/products/services/product_service.py
+++ b/swo/mpt/cli/core/products/services/product_service.py
@@ -1,5 +1,4 @@
 import json
-from typing import Any
 
 from requests_toolbelt import MultipartEncoder  # type: ignore
 from swo.mpt.cli.core.errors import MPTAPIError
@@ -40,19 +39,8 @@ class ProductService(BaseService):
         self._set_synced(product.id, product.coordinate)
         return ServiceResult(success=True, model=product, stats=self.stats)
 
-    def export(self, context: dict[str, Any]) -> ServiceResult:
-        """
-        Exports a product by retrieving it from the API and writing its data to a
-        new tab in a file.
-
-        Args:
-            context: A dictionary containing the product_id to export.
-
-        Returns:
-            ServiceResult: The result of the export operation.
-        """
-        product_id = context["product_id"]
-        result = self.retrieve_from_mpt(product_id)
+    def export(self, resource_id: str) -> ServiceResult:
+        result = self.retrieve_from_mpt(resource_id)
         product = result.model
         if not result.success or not product:
             return result

--- a/swo/mpt/cli/core/products/services/related_components_base_service.py
+++ b/swo/mpt/cli/core/products/services/related_components_base_service.py
@@ -1,13 +1,12 @@
 from abc import ABC
-from typing import Any
 
 from swo.mpt.cli.core.errors import MPTAPIError
 from swo.mpt.cli.core.models import DataCollectionModel
-from swo.mpt.cli.core.services.base_service import BaseService
+from swo.mpt.cli.core.services import RelatedBaseService
 from swo.mpt.cli.core.services.service_result import ServiceResult
 
 
-class RelatedComponentsBaseService(BaseService, ABC):
+class RelatedComponentsBaseService(RelatedBaseService, ABC):
     def create(self) -> ServiceResult:
         errors = []
         collection = {}
@@ -32,7 +31,7 @@ class RelatedComponentsBaseService(BaseService, ABC):
             stats=self.stats,
         )
 
-    def export(self, context: dict[str, Any]) -> ServiceResult:  # pragma: no cover
+    def export(self) -> ServiceResult:  # pragma: no cover
         return ServiceResult(
             success=False, errors=["Export method not implemented"], model=None, stats=self.stats
         )

--- a/swo/mpt/cli/core/services/__init__.py
+++ b/swo/mpt/cli/core/services/__init__.py
@@ -1,0 +1,6 @@
+from .base_service import BaseService, RelatedBaseService
+
+__all__ = [
+    "BaseService",
+    "RelatedBaseService",
+]

--- a/swo/mpt/cli/core/services/base_service.py
+++ b/swo/mpt/cli/core/services/base_service.py
@@ -1,11 +1,10 @@
 from abc import ABC, abstractmethod
-from typing import Any
 
 from swo.mpt.cli.core.services.service_context import ServiceContext
 from swo.mpt.cli.core.services.service_result import ServiceResult
 
 
-class BaseService(ABC):
+class Service(ABC):
     service_context: ServiceContext
 
     def __init__(self, service_context: ServiceContext):
@@ -19,16 +18,6 @@ class BaseService(ABC):
     def create(self) -> ServiceResult:  # pragma: no cover
         """
         Create a resource based on the definition file
-
-        Returns:
-            ServiceResult object with operation results
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def export(self, context: dict[str, Any]) -> ServiceResult:  # pragma: no cover
-        """
-        Export a resource from mpt to the file
 
         Returns:
             ServiceResult object with operation results
@@ -81,3 +70,30 @@ class BaseService(ABC):
 
     def _set_skipped(self):
         self.stats.add_skipped(self.file_manager.tab_name)
+
+
+class BaseService(Service, ABC):
+    @abstractmethod
+    def export(self, resource_id: str) -> ServiceResult:  # pragma: no cover
+        """
+        Export a resource from mpt to the file
+
+        Args:
+            resource_id: The ID of the product to export.
+
+        Returns:
+            ServiceResult object with operation results
+        """
+        raise NotImplementedError
+
+
+class RelatedBaseService(Service, ABC):
+    @abstractmethod
+    def export(self) -> ServiceResult:  # pragma: no cover
+        """
+        Export a resource from mpt to the file
+
+        Returns:
+            ServiceResult object with operation results
+        """
+        raise NotImplementedError

--- a/tests/test_swo/test_mpt/test_cli/test_core/test_pricelists/conftest.py
+++ b/tests/test_swo/test_mpt/test_cli/test_core/test_pricelists/conftest.py
@@ -300,91 +300,13 @@ def mpt_item_data():
             "id": "PRC-0232-2541-0002",
             "currency": "USD",
             "precision": 2,
-            "defaultMarkup": 42.0000000000,
-            "notes": "another price list",
-            "externalIds": {},
-            "statistics": {
-                "sellers": 0,
-                "listings": 0,
-                "priceListItems": 609,
-                "purchasePriceItems": 609,
-                "purchasePriceCompleteness": 100,
-                "salesPriceItems": 609,
-                "salesPriceCompleteness": 100,
-                "averageMarkup": 0.4128078817,
-                "averageMargin": 0.0000000000,
-            },
-            "product": {
-                "id": "PRD-0232-2541",
-                "name": "[DO NOT USE] Adobe VIP Marketplace for Commercial",
-                "externalIds": {},
-                "icon": "/v1/catalog/products/PRD-0232-2541/icon",
-                "status": "Unpublished",
-            },
-            "vendor": {
-                "id": "ACC-9226-9856",
-                "type": "Vendor",
-                "status": "Active",
-                "name": "Adobe",
-            },
-            "audit": {
-                "created": {
-                    "at": "2024-04-04T16:26:50.982Z",
-                    "by": {"id": "USR-0000-0022", "name": "User22"},
-                }
-            },
         },
         "item": {
             "id": "ITM-0232-2541-0002",
             "name": "Creative Cloud All Apps with Adobe Stock (10 assets per month)",
-            "description": "ITM-8351-9764 | AO03.15428.EN",
             "externalIds": {"vendor": "65322587CA", "operations": "1234567"},
-            "group": {"id": "IGR-0232-2541-0001", "name": "Items"},
-            "unit": {
-                "id": "UNT-1916",
-                "description": "When you purchase a product, a license represents your right to "
-                "use software and services. Licenses are used to authenticate and "
-                "activate the products on the end user's computers.",
-                "name": "user",
-            },
             "terms": {"period": "1y", "commitment": "1y"},
-            "quantityNotApplicable": False,
-            "status": "Published",
-            "product": {
-                "id": "PRD-0232-2541",
-                "name": "[DO NOT USE] Adobe VIP Marketplace for Commercial",
-                "externalIds": {},
-                "icon": "/v1/catalog/products/PRD-0232-2541/icon",
-                "status": "Unpublished",
-            },
-            "parameters": [
-                {
-                    "id": "PAR-0232-2541-0004",
-                    "externalId": "type",
-                    "type": "DropDown",
-                    "name": "Type",
-                    "value": "Teams",
-                    "displayValue": "Teams",
-                },
-                {
-                    "id": "PAR-0232-2541-0005",
-                    "externalId": "language",
-                    "type": "SingleLineText",
-                    "name": "Language",
-                    "value": "English - Europe",
-                    "displayValue": "English - Europe",
-                },
-            ],
-            "audit": {
-                "created": {
-                    "at": "2024-03-19T12:03:51.504Z",
-                    "by": {"id": "USR-0000-0022", "name": "User22"},
-                },
-                "updated": {
-                    "at": "2024-04-23T11:03:24.411Z",
-                    "by": {"id": "USR-0081-7601", "name": "User7601"},
-                },
-            },
+            "status": "ForSale",
         },
         "audit": {
             "created": {

--- a/tests/test_swo/test_mpt/test_cli/test_core/test_pricelists/test_services/test_item_service.py
+++ b/tests/test_swo/test_mpt/test_cli/test_core/test_pricelists/test_services/test_item_service.py
@@ -30,7 +30,7 @@ def test_export(mocker, service_context, mpt_item_data):
     response_data = {"data": [mpt_item_data], "meta": {"offset": 1, "limit": 100, "total": 1}}
     api_list_mock = mocker.patch.object(service_context.api, "list", side_effect=[response_data])
 
-    result = ItemService(service_context).export({"price_list": mocker.Mock(precision=2)})
+    result = ItemService(service_context).export()
 
     assert result.success is True
     create_tab_mock.assert_called_once()
@@ -45,7 +45,7 @@ def test_export_mpt_error(mocker, service_context):
     )
     add_spy = mocker.spy(service_context.file_manager, "add")
 
-    result = ItemService(service_context).export({"price_list": mocker.Mock(precision=2)})
+    result = ItemService(service_context).export()
 
     assert result.success is False
     create_tab_mock.assert_called_once()

--- a/tests/test_swo/test_mpt/test_cli/test_core/test_products/test_models/test_product.py
+++ b/tests/test_swo/test_mpt/test_cli/test_core/test_products/test_models/test_product.py
@@ -68,7 +68,7 @@ def test_product_data_to_json(product_data_from_dict):
         "name": "Adobe Commerce (CLI Test)",
         "shortDescription": "Catalog description",
         "longDescription": "Product description",
-        "website": "https://example.com"
+        "website": "https://example.com",
     }
 
 
@@ -122,7 +122,7 @@ def test_settings_data_from_json(mpt_product_data):
 def test_settings_data_to_xlsx(product_data_from_dict):
     result = product_data_from_dict.settings.to_json()
 
-    assert result == {'itemSelection': False}
+    assert result == {"itemSelection": False}
 
 
 def test_setting_item_from_dict(settings_file_data):

--- a/tests/test_swo/test_mpt/test_cli/test_core/test_products/test_services/test_related_components_base_service.py
+++ b/tests/test_swo/test_mpt/test_cli/test_core/test_products/test_services/test_related_components_base_service.py
@@ -1,4 +1,3 @@
-from typing import Any
 from unittest.mock import Mock
 
 import pytest
@@ -13,7 +12,7 @@ from swo.mpt.cli.core.stats import ProductStatsCollector
 
 
 class FakeRelatedComponentsService(RelatedComponentsBaseService):
-    def export(self, context: dict[str, Any]) -> ServiceResult:
+    def export(self) -> ServiceResult:
         pass
 
     def retrieve(self) -> ServiceResult:


### PR DESCRIPTION
Add related base service to be inherit from related components. 


### Changes
* Added Service as the parent of BaseService and RelatedBaseService. 
* Implement BaseService and RelatedService to include the export method interface.
* Remove `precision` and `currency` attributes from FileManager add method. These, are now part of the model.

