### PR TITLE
MPT-11633: add service providers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
+    "dependency-injector==4.48.*",
     "openpyxl==3.1.*",
     "pydantic==2.11.*",
     "pyfiglet==1.0.*",

--- a/swo/mpt/cli/core/accounts/containers.py
+++ b/swo/mpt/cli/core/accounts/containers.py
@@ -1,0 +1,17 @@
+from dependency_injector import containers, providers
+from swo.mpt.cli.core.accounts.app import get_active_account
+from swo.mpt.cli.core.mpt.client import client_from_account
+
+
+class AccountContainer(containers.DeclarativeContainer):
+    """
+    Container for account-related services and components.
+
+    Attributes:
+        account: Provides the active account.
+        mpt_client: Provides the MPT client based on the active account.
+
+    """
+
+    account = providers.Singleton(get_active_account)
+    mpt_client = providers.Singleton(client_from_account, account)

--- a/swo/mpt/cli/core/price_lists/app.py
+++ b/swo/mpt/cli/core/price_lists/app.py
@@ -92,7 +92,7 @@ def sync_price_lists(
         with console.status("Sync Price list Items..."):
             result = price_list_item_service.update()
 
-        stats.price_list_id = price_list.id
+        stats.id = price_list.id
         console.print(stats.to_table())
 
     if has_error:

--- a/swo/mpt/cli/core/products/containers.py
+++ b/swo/mpt/cli/core/products/containers.py
@@ -1,0 +1,167 @@
+from functools import partial
+
+from dependency_injector import containers, providers
+from swo.mpt.cli.core.accounts.containers import AccountContainer
+from swo.mpt.cli.core.products.api import (
+    ItemAPIService,
+    ItemGroupAPIService,
+    ParameterGroupAPIService,
+    ParametersAPIService,
+    ProductAPIService,
+    TemplateAPIService,
+)
+from swo.mpt.cli.core.products.handlers import (
+    AgreementParametersExcelFileManager,
+    ItemExcelFileManager,
+    ItemGroupExcelFileManager,
+    ItemParametersExcelFileManager,
+    ParameterGroupExcelFileManager,
+    ProductExcelFileManager,
+    RequestParametersExcelFileManager,
+    SettingsExcelFileManager,
+    SubscriptionParametersExcelFileManager,
+    TemplateExcelFileManager,
+)
+from swo.mpt.cli.core.products.models import (
+    AgreementParametersData,
+    ItemData,
+    ItemGroupData,
+    ParameterGroupData,
+    ProductData,
+    TemplateData,
+)
+from swo.mpt.cli.core.products.services import (
+    ItemGroupService,
+    ItemService,
+    ParameterGroupService,
+    ParametersService,
+    ProductService,
+    TemplateService,
+)
+from swo.mpt.cli.core.services.service_context import ServiceContext
+from swo.mpt.cli.core.stats import ProductStatsCollector
+
+
+class ProductContainer(containers.DeclarativeContainer):
+    """Container for product service.
+
+    Attributes:
+        product_service: Factory provider for the ProductService.
+        item_service: Factory provider for the ItemService.
+        item_group_service: Factory provider for the ItemGroupService.
+        parameter_group_service: Factory provider for the ParameterGroupService.
+        agreement_parameters_service: Factory provider for the Agreement parameters.
+        item_parameters_service: Factory provider for the Item parameters.
+        request_parameters_service: Factory provider for the Request parameters.
+        subscription_parameters_service: Factory provider for the Subscription parameters.
+        template_service: Factory provider for the TemplateService.
+
+    """
+
+    account_container = providers.Container(AccountContainer)
+    _account = providers.Factory(account_container.account)
+    _mpt_client = providers.Factory(account_container.mpt_client)
+    resource_id = providers.Dependency(instance_of=str, default="")
+    file_path = providers.Dependency(instance_of=str)
+    stats = providers.Dependency(instance_of=ProductStatsCollector, default=ProductStatsCollector())
+
+    _apis = providers.Dict(
+        product=providers.Factory(ProductAPIService, _mpt_client),
+        items=providers.Factory(ItemAPIService, _mpt_client, resource_id),
+        item_group=providers.Factory(ItemGroupAPIService, _mpt_client, resource_id),
+        parameter_group=providers.Factory(ParameterGroupAPIService, _mpt_client, resource_id),
+        parameters=providers.Factory(ParametersAPIService, _mpt_client, resource_id),
+        template=providers.Factory(TemplateAPIService, _mpt_client, resource_id),
+    )
+
+    _file_managers = providers.Dict(
+        product=providers.Factory(ProductExcelFileManager, file_path),
+        items=providers.Factory(ItemExcelFileManager, file_path),
+        item_group=providers.Factory(ItemGroupExcelFileManager, file_path),
+        parameter_group=providers.Factory(ParameterGroupExcelFileManager, file_path),
+        agreement_parameters=providers.Factory(AgreementParametersExcelFileManager, file_path),
+        item_parameters=providers.Factory(ItemParametersExcelFileManager, file_path),
+        request_parameters=providers.Factory(RequestParametersExcelFileManager, file_path),
+        subscription_parameters=providers.Factory(
+            SubscriptionParametersExcelFileManager, file_path
+        ),
+        template=providers.Factory(TemplateExcelFileManager, file_path),
+        settings=providers.Factory(SettingsExcelFileManager, file_path),
+    )
+
+    _services = {
+        "product": {
+            "api": _apis.provided["product"],
+            "data_model": ProductData,
+            "file_manager": _file_managers.provided["product"],
+        },
+        "items": {
+            "api": _apis.provided["items"],
+            "data_model": ItemData,
+            "file_manager": _file_managers.provided["items"],
+        },
+        "item_group": {
+            "api": _apis.provided["item_group"],
+            "data_model": ItemGroupData,
+            "file_manager": _file_managers.provided["item_group"],
+        },
+        "parameter_group": {
+            "api": _apis.provided["parameter_group"],
+            "data_model": ParameterGroupData,
+            "file_manager": _file_managers.provided["parameter_group"],
+        },
+        "agreement_parameters": {
+            "api": _apis.provided["parameters"],
+            "data_model": AgreementParametersData,
+            "file_manager": _file_managers.provided["agreement_parameters"],
+        },
+        "item_parameters": {
+            "api": _apis.provided["parameters"],
+            "data_model": AgreementParametersData,
+            "file_manager": _file_managers.provided["item_parameters"],
+        },
+        "request_parameters": {
+            "api": _apis.provided["parameters"],
+            "data_model": AgreementParametersData,
+            "file_manager": _file_managers.provided["request_parameters"],
+        },
+        "subscription_parameters": {
+            "api": _apis.provided["parameters"],
+            "data_model": AgreementParametersData,
+            "file_manager": _file_managers.provided["subscription_parameters"],
+        },
+        "template": {
+            "api": _apis.provided["template"],
+            "data_model": TemplateData,
+            "file_manager": _file_managers.provided["template"],
+        },
+    }
+    _partial_context = partial(providers.Factory, ServiceContext, account=_account, stats=stats)
+
+    product_service = providers.Factory(
+        ProductService, service_context=_partial_context(**_services["product"])
+    )
+    item_service = providers.Factory(
+        ItemService, service_context=_partial_context(**_services["items"])
+    )
+    item_group_service = providers.Factory(
+        ItemGroupService, service_context=_partial_context(**_services["item_group"])
+    )
+    parameter_group_service = providers.Factory(
+        ParameterGroupService, service_context=_partial_context(**_services["parameter_group"])
+    )
+    agreement_parameters_service = providers.Factory(
+        ParametersService, service_context=_partial_context(**_services["agreement_parameters"])
+    )
+    item_parameters_service = providers.Factory(
+        ParametersService, service_context=_partial_context(**_services["item_parameters"])
+    )
+    request_parameters_service = providers.Factory(
+        ParametersService, service_context=_partial_context(**_services["request_parameters"])
+    )
+    subscription_parameters_service = providers.Factory(
+        ParametersService, service_context=_partial_context(**_services["subscription_parameters"])
+    )
+    template_service = providers.Factory(
+        TemplateService, service_context=_partial_context(**_services["template"])
+    )

--- a/swo/mpt/cli/core/products/services/item_service.py
+++ b/swo/mpt/cli/core/products/services/item_service.py
@@ -67,7 +67,17 @@ class ItemService(RelatedComponentsBaseService):
 
         return ServiceResult(success=len(errors) == 0, errors=errors, model=None, stats=self.stats)
 
-    def set_new_item_groups(self, item_groups: DataCollectionModel) -> None:
+    def set_new_item_groups(self, item_groups: DataCollectionModel | None) -> None:
+        """
+        Update item group references in item content.
+
+        Args:
+            item_groups: A collection of item groups to update.
+
+        """
+        if item_groups is None or not item_groups.collection:
+            return None
+
         for item in self.file_manager.read_data():
             try:
                 new_group = item_groups.retrieve_by_id(item.group_id)
@@ -75,6 +85,8 @@ class ItemService(RelatedComponentsBaseService):
                 continue
 
             self.file_manager.write_id(item.group_coordinate, new_group.id)
+
+        return None
 
     def set_export_params(self) -> dict[str, Any]:
         params = super().set_export_params()

--- a/swo/mpt/cli/core/products/services/parameters_service.py
+++ b/swo/mpt/cli/core/products/services/parameters_service.py
@@ -8,6 +8,16 @@ from swo.mpt.cli.core.products.services.related_components_base_service import (
 
 class ParametersService(RelatedComponentsBaseService):
     def set_new_parameter_group(self, parameter_groups: DataCollectionModel) -> None:
+        """
+        Update parameter group references in parameter content.
+
+        Args:
+            parameter_groups: A collection of parameter groups to update.
+
+        """
+        if not parameter_groups.collection or parameter_groups is None:
+            return None
+
         for data_model in self.file_manager.read_data():
             try:
                 new_group = parameter_groups.retrieve_by_id(data_model.group_id)
@@ -15,6 +25,8 @@ class ParametersService(RelatedComponentsBaseService):
                 continue
 
             self.file_manager.write_id(data_model.group_id_coordinate, new_group.id)
+
+        return None
 
     def set_export_params(self) -> dict[str, Any]:
         params = super().set_export_params()

--- a/swo/mpt/cli/core/products/services/template_service.py
+++ b/swo/mpt/cli/core/products/services/template_service.py
@@ -5,7 +5,17 @@ from swo.mpt.cli.core.products.services.related_components_base_service import (
 
 
 class TemplateService(RelatedComponentsBaseService):
-    def set_new_parameter_group(self, param_groups: DataCollectionModel) -> None:
+    def set_new_parameter_group(self, param_groups: DataCollectionModel | None) -> None:
+        """
+        Update parameter group references in template content.
+
+        Args:
+            param_groups: A collection of parameter groups to update.
+
+        """
+        if param_groups is None or not param_groups.collection:
+            return None
+
         for data_model in self.file_manager.read_data():
             content = data_model.content
 
@@ -15,3 +25,5 @@ class TemplateService(RelatedComponentsBaseService):
 
                 content = content.replace(id, item.id)
                 self.file_manager.write_id(data_model.content_coordinate, content)
+
+        return None

--- a/swo/mpt/cli/core/services/__init__.py
+++ b/swo/mpt/cli/core/services/__init__.py
@@ -3,4 +3,5 @@ from .base_service import BaseService, RelatedBaseService
 __all__ = [
     "BaseService",
     "RelatedBaseService",
+    "ServiceProvider",
 ]

--- a/swo/mpt/cli/core/stats.py
+++ b/swo/mpt/cli/core/stats.py
@@ -71,6 +71,22 @@ class StatsCollector(ABC):
         self.__has_error = False
         self.__tab_aliases = tabs
 
+    @property
+    def id(self) -> str | None:
+        return self.__id
+
+    @id.setter
+    def id(self, value: str) -> None:
+        self.__id = value
+
+    @property
+    def tabs(self) -> dict[str, Results]:
+        return self.__tab_aliases
+
+    @property
+    def has_errors(self) -> bool:
+        return self.__has_error
+
     def add_error(self, tab_name: str) -> None:
         self.__tab_aliases[tab_name]["error"] += 1
         self.__tab_aliases[tab_name]["total"] += 1
@@ -83,14 +99,6 @@ class StatsCollector(ABC):
     def add_skipped(self, tab_name: str) -> None:
         self.__tab_aliases[tab_name]["skipped"] += 1
         self.__tab_aliases[tab_name]["total"] += 1
-
-    @property
-    def tabs(self) -> dict[str, Results]:
-        return self.__tab_aliases
-
-    @property
-    def is_error(self) -> bool:
-        return self.__has_error
 
     @abstractmethod
     def _get_table_title(self) -> str:  # pragma: no cover
@@ -140,7 +148,7 @@ class ProductStatsCollector(StatsCollector):
         super().__init__(tabs)
 
     def _get_table_title(self) -> str:
-        status = "[red bold]FAILED" if self.is_error else "[green bold]SUCCEED"
+        status = "[red bold]FAILED" if self.has_errors else "[green bold]SUCCEED"
         return f"Product Sync {status}"
 
 
@@ -153,21 +161,12 @@ class PriceListStatsCollector(StatsCollector):
             "General": general,
             "Price Items": price_items,
         }
-
         super().__init__(tabs)
 
-    @property
-    def price_list_id(self) -> str | None:
-        return self.__id
-
-    @price_list_id.setter
-    def price_list_id(self, value: str) -> None:
-        self.__id = value
-
     def _get_table_title(self) -> str:
-        if self.is_error:
+        if self.has_errors:
             title = "Pricelist sync [red bold]FAILED"
         else:
-            title = f"Pricelist {self.price_list_id} sync [green bold]SUCCEED"
+            title = f"Pricelist {self.id} sync [green bold]SUCCEED"
 
         return title

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,24 @@
 import shutil
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 import responses
+from swo.mpt.cli.core.accounts.containers import AccountContainer
 from swo.mpt.cli.core.accounts.models import Account as CLIAccount
 from swo.mpt.cli.core.mpt.client import MPTClient
 from swo.mpt.cli.core.mpt.models import Account, Product
+
+
+@pytest.fixture
+def account_container_mock(mocker, operations_account):
+    container = AccountContainer()
+    container.account.override(MagicMock(return_value=operations_account))
+    container.mpt_client.override(MagicMock(MPTClient))
+    mock = mocker.patch("swo.mpt.cli.core.products.app.AccountContainer", autospec=True)
+    mock.return_value = container
+
+    return container
 
 
 @pytest.fixture

--- a/tests/test_swo/test_mpt/test_cli/test_core/test_products/conftest.py
+++ b/tests/test_swo/test_mpt/test_cli/test_core/test_products/conftest.py
@@ -1,6 +1,7 @@
 import shutil
 from datetime import datetime
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 from freezegun import freeze_time
@@ -74,6 +75,7 @@ from swo.mpt.cli.core.products.constants import (
     TEMPLATES_NAME,
     TEMPLATES_TYPE,
 )
+from swo.mpt.cli.core.products.containers import ProductContainer
 from swo.mpt.cli.core.products.models import (
     AgreementParametersData,
     ItemData,
@@ -85,6 +87,33 @@ from swo.mpt.cli.core.products.models import (
 )
 from swo.mpt.cli.core.products.models.items import ItemAction
 from swo.mpt.cli.core.products.models.product import SettingsItem
+from swo.mpt.cli.core.products.services import (
+    ItemGroupService,
+    ItemService,
+    ParameterGroupService,
+    ParametersService,
+    ProductService,
+    TemplateService,
+)
+
+
+@pytest.fixture
+def product_container_mock(mocker, account_container_mock):
+    container = ProductContainer()
+    container.account_container.override(account_container_mock)
+    container.product_service.override(MagicMock(ProductService))
+    container.item_service.override(MagicMock(ItemService))
+    container.item_group_service.override(MagicMock(ItemGroupService))
+    container.parameter_group_service.override(MagicMock(ParameterGroupService))
+    container.agreement_parameters_service.override(MagicMock(ParametersService))
+    container.item_parameters_service.override(MagicMock(ParametersService))
+    container.request_parameters_service.override(MagicMock(ParametersService))
+    container.subscription_parameters_service.override(MagicMock(ParametersService))
+    container.template_service.override(MagicMock(TemplateService))
+    mock = mocker.patch("swo.mpt.cli.core.products.app.ProductContainer", autospec=True)
+    mock.return_value = container
+
+    return container
 
 
 @pytest.fixture

--- a/tests/test_swo/test_mpt/test_cli/test_core/test_products/test_services/test_item_service.py
+++ b/tests/test_swo/test_mpt/test_cli/test_core/test_products/test_services/test_item_service.py
@@ -228,6 +228,17 @@ def test_set_new_item_groups_error(
     write_id_mock.assert_not_called()
 
 
+def test_set_new_parameter_groups_empty(mocker, service_context):
+    read_data_spy = mocker.spy(service_context.file_manager, "read_data")
+    write_id_spy = mocker.spy(service_context.file_manager, "write_id")
+    service = ItemService(service_context)
+
+    service.set_new_item_groups(DataCollectionModel(collection={}))
+
+    read_data_spy.assert_not_called()
+    write_id_spy.assert_not_called()
+
+
 def test_set_export_params(service_context, item_data_from_dict):
     service = ItemService(service_context)
 

--- a/tests/test_swo/test_mpt/test_cli/test_core/test_products/test_services/test_parameters_service.py
+++ b/tests/test_swo/test_mpt/test_cli/test_core/test_products/test_services/test_parameters_service.py
@@ -54,6 +54,17 @@ def test_set_new_parameter_groups_error(
     write_id_mock.assert_not_called()
 
 
+def test_set_new_parameter_groups_empty(mocker, service_context):
+    read_data_spy = mocker.spy(service_context.file_manager, "read_data")
+    write_id_spy = mocker.spy(service_context.file_manager, "write_id")
+    service = ParametersService(service_context)
+
+    service.set_new_parameter_group(DataCollectionModel(collection={}))
+
+    read_data_spy.assert_not_called()
+    write_id_spy.assert_not_called()
+
+
 def test_set_export_params(service_context, parameters_data_from_dict):
     service = ParametersService(service_context)
 

--- a/tests/test_swo/test_mpt/test_cli/test_core/test_products/test_services/test_product_service.py
+++ b/tests/test_swo/test_mpt/test_cli/test_core/test_products/test_services/test_product_service.py
@@ -141,6 +141,16 @@ def test_validate_definition(mocker, service_context):
     assert result.model is None
 
 
+def test_validate_definition_file_doesnt_exist(mocker, service_context):
+    mocker.patch.object(service_context.file_manager.file_handler, "exists", return_value=False)
+
+    service = ProductService(service_context)
+    result = service.validate_definition()
+
+    assert result.success is False
+    assert result.errors == ["Provided file path doesn't exist"]
+
+
 def test_validate_definition_missing_tabs(mocker, service_context):
     mocker.patch.object(
         service_context.file_manager,

--- a/tests/test_swo/test_mpt/test_cli/test_core/test_products/test_services/test_template_service.py
+++ b/tests/test_swo/test_mpt/test_cli/test_core/test_products/test_services/test_template_service.py
@@ -38,3 +38,14 @@ def test_set_new_parameter_group(
     write_id_mock.assert_called_once_with(
         template_data_from_dict.content_coordinate, f"{parameter_group_data_from_dict.id}: bla"
     )
+
+
+def test_set_new_parameter_groups_empty(mocker, service_context):
+    read_data_spy = mocker.spy(service_context.file_manager, "read_data")
+    write_id_spy = mocker.spy(service_context.file_manager, "write_id")
+    service = TemplateService(service_context)
+
+    service.set_new_parameter_group(DataCollectionModel(collection={}))
+
+    read_data_spy.assert_not_called()
+    write_id_spy.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -276,6 +276,21 @@ wheels = [
 ]
 
 [[package]]
+name = "dependency-injector"
+version = "4.48.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/7c/5062c4a7ffd32bf210ff55fab9d279a5beeae350fb09533d3536811e13b6/dependency_injector-4.48.1.tar.gz", hash = "sha256:1805185e4522effad6d5e348c255d27e80d3f8adc89701daf13d743367392978", size = 1100885, upload-time = "2025-06-20T10:21:52.248Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/f9/c9b77652f724aece8856e281f7a71e5af544049b3c068df70c68868e43be/dependency_injector-4.48.1-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:a6f73011d532f3ea59689aad85c7999be6da3f30393041a745d5861cdcdc02e4", size = 1631637, upload-time = "2025-06-20T10:21:24.729Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f0/d91c9cdabb1f2354762aca588757d1aa341f3cbccbc8636dd2c06acac10b/dependency_injector-4.48.1-cp38-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ac09f508fa9aee06a036ebf3e3d3b2a210276aba1993e9993cec7f1fdc5fd89e", size = 1855944, upload-time = "2025-06-20T10:21:26.753Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ee/d69c4758a12653edbe6ee15c0bf4195981c9820650a1cfa762cbb838485b/dependency_injector-4.48.1-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b05a4a980096b53ad90a87965c5450183bfbb8bbe36615d7cea97537086d622", size = 1811989, upload-time = "2025-06-20T10:21:28.293Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/6d/d2a257402c8c3f7a9c61f1b8a0482ec4373f1ef7fdfe784a91e883506e3b/dependency_injector-4.48.1-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0506e98440ee6c48fe660016d602961b1b3ecc0a8227838a2221048ed11e2fca", size = 1826408, upload-time = "2025-06-20T10:21:29.789Z" },
+    { url = "https://files.pythonhosted.org/packages/65/f9/2a408d460eedb264f7ea919754c526c8f3a18c026496cacb7dd6960766d2/dependency_injector-4.48.1-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1994622eae8917138626303b176cba4c74e625ba1e588cb09d673ca175d299a2", size = 1863948, upload-time = "2025-06-20T10:21:31.951Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/8a/2edaef77e725dd8b1a625c84cbccb0f445afe58277c7b243cbf58784826a/dependency_injector-4.48.1-cp38-abi3-win32.whl", hash = "sha256:58d4d81f92e3267c331f160cbbb517fd7644b95ee57a0d6e4b01f53a7e437a4a", size = 1516768, upload-time = "2025-06-20T10:21:33.747Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/41/4bf523af7e1b7f367499f8b8709e0e807e9a14c7d1674b0442d7f84403c8/dependency_injector-4.48.1-cp38-abi3-win_amd64.whl", hash = "sha256:572b22b7db9b103718ea52634b5ca1ef763278338310254334f4633a57c9f0e7", size = 1639850, upload-time = "2025-06-20T10:21:35.639Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.3.9"
 source = { registry = "https://pypi.org/simple" }
@@ -614,6 +629,7 @@ name = "mpt-cli"
 version = "2.0.0"
 source = { editable = "." }
 dependencies = [
+    { name = "dependency-injector" },
     { name = "openpyxl" },
     { name = "pydantic" },
     { name = "pyfiglet" },
@@ -646,6 +662,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "dependency-injector", specifier = ">=4.48.1" },
     { name = "openpyxl", specifier = "==3.1.*" },
     { name = "pydantic", specifier = "==2.11.*" },
     { name = "pyfiglet", specifier = "==1.0.*" },


### PR DESCRIPTION
Add service providers using the [dependency-injector](https://python-dependency-injector.ets-labs.org/index.html) library. The containers allow us to isolate the configuration needed by each service, improving modularity and maintainability. Now, the CLI commands don't need to know how the services are instantiated, they just using them.

### Changes

* Installed the `depencency-injector` package
* Added `ProductContainer` 
* Updated product create and export commands to use the container
* Updated tests