### PR TITLE
MPT-11559: add related components actions to the update flow.

### DIFF
--- a/swo/mpt/cli/core/products/app.py
+++ b/swo/mpt/cli/core/products/app.py
@@ -4,6 +4,7 @@ from typing import Annotated
 
 import typer
 from rich import box
+from rich.status import Status
 from rich.table import Table
 from swo.mpt.cli.core.accounts.app import get_active_account
 from swo.mpt.cli.core.accounts.containers import AccountContainer
@@ -253,9 +254,42 @@ def create_product(container, status):
     return None
 
 
-def update_product(container, status):
+def update_product(container: ProductContainer, status: Status):
+    """
+    Update product definition.
+    Args:
+        container: The product container instance.
+        status: The status object used to display progress.
+
+    """
+    # NOTE: the order cannot be changed to ensure the related components are handled before
+    # its group.
+    status.update("Update product...")
+    container.product_service().update()
+
     status.update(f"Update item for {container.resource_id}...")
     container.item_service().update()
+
+    status.update(f"Update items groups for product {container.resource_id}...")
+    container.item_group_service().update()
+
+    status.update(f"Update subscription parameters for product {container.resource_id}...")
+    container.template_service().update()
+
+    status.update(f"Update parameters groups for product {container.resource_id}...")
+    container.parameter_group_service().update()
+
+    status.update(f"Update agreement parameters for product {container.resource_id}...")
+    container.agreement_parameters_service().update()
+
+    status.update(f"Update item parameters for product {container.resource_id}...")
+    container.item_parameters_service().update()
+
+    status.update(f"Update request parameters for product {container.resource_id}...")
+    container.request_parameters_service().update()
+
+    status.update(f"Update subscription parameters for product {container.resource_id}...")
+    container.subscription_parameters_service().update()
 
 
 # TODO: move to to_table()

--- a/swo/mpt/cli/core/products/models/__init__.py
+++ b/swo/mpt/cli/core/products/models/__init__.py
@@ -1,4 +1,4 @@
-from .data_actions import DataActionEnum
+from .data_actions import DataActionEnum, ItemActionEnum
 from .item_group import ItemGroupData
 from .items import ItemData
 from .parameter_group import ParameterGroupData
@@ -14,6 +14,7 @@ from .template import TemplateData
 __all__ = [
     "AgreementParametersData",
     "DataActionEnum",
+    "ItemActionEnum",
     "ItemData",
     "ItemGroupData",
     "ItemParametersData",

--- a/swo/mpt/cli/core/products/models/data_actions.py
+++ b/swo/mpt/cli/core/products/models/data_actions.py
@@ -6,3 +6,14 @@ class DataActionEnum(StrEnum):
     DELETE = "delete"
     UPDATE = "update"
     SKIP = "-"
+    SKIPPED = ""
+
+
+class ItemActionEnum(StrEnum):
+    CREATE = "create"
+    UPDATE = "update"
+    REVIEW = "review"
+    PUBLISH = "publish"
+    UNPUBLISH = "unpublish"
+    SKIP = "-"
+    SKIPPED = ""

--- a/swo/mpt/cli/core/products/models/item_group.py
+++ b/swo/mpt/cli/core/products/models/item_group.py
@@ -5,11 +5,11 @@ from typing import Any, Self
 from dateutil import parser
 from swo.mpt.cli.core.models import BaseDataModel
 from swo.mpt.cli.core.products import constants
-from swo.mpt.cli.core.products.models.data_actions import DataActionEnum
+from swo.mpt.cli.core.products.models.mixins import ActionMixin
 
 
 @dataclass
-class ItemGroupData(BaseDataModel):
+class ItemGroupData(BaseDataModel, ActionMixin):
     id: str
     default: bool
     description: str
@@ -19,7 +19,6 @@ class ItemGroupData(BaseDataModel):
     name: str
     required: bool
 
-    action: DataActionEnum = DataActionEnum.SKIP
     coordinate: str | None = None
     created_date: date | None = None
     updated_date: date | None = None

--- a/swo/mpt/cli/core/products/models/items.py
+++ b/swo/mpt/cli/core/products/models/items.py
@@ -1,25 +1,15 @@
 from dataclasses import dataclass, field
 from datetime import date
-from enum import StrEnum
 from typing import Any, Self
 
 from dateutil import parser
 from swo.mpt.cli.core.models import BaseDataModel
 from swo.mpt.cli.core.products import constants
-
-
-class ItemAction(StrEnum):
-    CREATE = "create"
-    UPDATE = "update"
-    REVIEW = "review"
-    PUBLISH = "publish"
-    UNPUBLISH = "unpublish"
-    SKIP = "-"
-    SKIPPED = ""
+from swo.mpt.cli.core.products.models.mixins import ItemActionMixin
 
 
 @dataclass
-class ItemData(BaseDataModel):
+class ItemData(BaseDataModel, ItemActionMixin):
     id: str
     description: str
     group_id: str
@@ -29,7 +19,6 @@ class ItemData(BaseDataModel):
     unit_id: str
     vendor_id: str
 
-    action: ItemAction = ItemAction.SKIP
     commitment: str | None = None
     coordinate: str | None = None
     group_coordinate: str | None = None
@@ -63,30 +52,6 @@ class ItemData(BaseDataModel):
             data["commitment"] = self.commitment  # type: ignore
 
         return data
-
-    @property
-    def to_create(self) -> bool:
-        return self.action == ItemAction.CREATE
-
-    @property
-    def to_publish(self) -> bool:
-        return self.action == ItemAction.PUBLISH
-
-    @property
-    def to_review(self) -> bool:
-        return self.action == ItemAction.REVIEW
-
-    @property
-    def to_skip(self) -> bool:
-        return self.action == ItemAction.SKIP or self.action == ItemAction.SKIPPED
-
-    @property
-    def to_unpublish(self) -> bool:
-        return self.action == ItemAction.UNPUBLISH
-
-    @property
-    def to_update(self) -> bool:
-        return self.action == ItemAction.UPDATE
 
     @property
     def unit(self) -> dict[str, Any]:

--- a/swo/mpt/cli/core/products/models/mixins.py
+++ b/swo/mpt/cli/core/products/models/mixins.py
@@ -1,0 +1,78 @@
+from dataclasses import dataclass
+
+from swo.mpt.cli.core.products.models import DataActionEnum, ItemActionEnum
+
+
+@dataclass(kw_only=True)
+class ActionMixin:
+    """
+    Mixin class providing action-related functionality for data models.
+    """
+
+    action: DataActionEnum = DataActionEnum.SKIP
+
+    @property
+    def to_create(self) -> bool:
+        """Check if the object is marked for creation.
+
+        Returns:
+            True if the object should be created, False otherwise.
+        """
+        return self.action == DataActionEnum.CREATE
+
+    @property
+    def to_update(self) -> bool:
+        """Check if the object is marked for update.
+
+        Returns:
+            True if the object should be updated, False otherwise.
+        """
+        return self.action == DataActionEnum.UPDATE
+
+    @property
+    def to_delete(self) -> bool:
+        """Check if the object is marked for deletion.
+
+        Returns:
+            True if the object should be deleted, False otherwise.
+        """
+        return self.action == DataActionEnum.DELETE
+
+    @property
+    def to_skip(self) -> bool:
+        """Check if the object should be skipped.
+
+        Returns:
+            True if the object should be skipped, False otherwise.
+        """
+        return self.action in (DataActionEnum.SKIP, DataActionEnum.SKIPPED)
+
+
+@dataclass
+class ItemActionMixin(ActionMixin):
+    @property
+    def to_review(self) -> bool:
+        """Check if the object is marked for review.
+
+        Returns:
+            True if the object should be reviewed, False otherwise.
+        """
+        return self.action == ItemActionEnum.REVIEW
+
+    @property
+    def to_publish(self) -> bool:
+        """Check if the object is marked for publication.
+
+        Returns:
+            True if the object should be published, False otherwise.
+        """
+        return self.action == ItemActionEnum.PUBLISH
+
+    @property
+    def to_unpublish(self) -> bool:
+        """Check if the object is marked for unpublication.
+
+        Returns:
+            True if the object should be unpublished, False otherwise.
+        """
+        return self.action == ItemActionEnum.UNPUBLISH

--- a/swo/mpt/cli/core/products/models/parameter_group.py
+++ b/swo/mpt/cli/core/products/models/parameter_group.py
@@ -5,11 +5,11 @@ from typing import Any, Self
 from dateutil import parser
 from swo.mpt.cli.core.models import BaseDataModel
 from swo.mpt.cli.core.products import constants
-from swo.mpt.cli.core.products.models.data_actions import DataActionEnum
+from swo.mpt.cli.core.products.models.mixins import ActionMixin
 
 
 @dataclass
-class ParameterGroupData(BaseDataModel):
+class ParameterGroupData(BaseDataModel, ActionMixin):
     id: str
     default: bool
     description: str
@@ -17,7 +17,6 @@ class ParameterGroupData(BaseDataModel):
     label: str
     name: str
 
-    action: DataActionEnum = DataActionEnum.SKIP
     coordinate: str | None = None
     created_date: date | None = None
     updated_date: date | None = None

--- a/swo/mpt/cli/core/products/models/parameters.py
+++ b/swo/mpt/cli/core/products/models/parameters.py
@@ -9,6 +9,7 @@ from dateutil import parser
 from swo.mpt.cli.core.models import BaseDataModel
 from swo.mpt.cli.core.products import constants
 from swo.mpt.cli.core.products.models import DataActionEnum
+from swo.mpt.cli.core.products.models.mixins import ActionMixin
 
 BaseParametersData = TypeVar("BaseParametersData", bound="ParametersData")
 
@@ -21,7 +22,7 @@ class ParamScopeEnum(StrEnum):
 
 
 @dataclass
-class ParametersData(BaseDataModel, ABC):
+class ParametersData(BaseDataModel, ActionMixin, ABC):
     id: str
     description: str
     display_order: int
@@ -32,7 +33,6 @@ class ParametersData(BaseDataModel, ABC):
     constraints: dict[str, Any]
     options: dict[str, Any]
 
-    action: DataActionEnum = DataActionEnum.SKIP
     coordinate: str | None = None
     group_id: str | None = None
     group_id_coordinate: str | None = None

--- a/swo/mpt/cli/core/products/models/product.py
+++ b/swo/mpt/cli/core/products/models/product.py
@@ -7,24 +7,24 @@ from typing import Any, Self
 from dateutil import parser
 from swo.mpt.cli.core.models.data_model import BaseDataModel
 from swo.mpt.cli.core.products import constants
-from swo.mpt.cli.core.products.models import DataActionEnum
+from swo.mpt.cli.core.products.models.mixins import ActionMixin
 from swo.mpt.cli.core.utils import set_dict_value
 
 
 @dataclass
-class SettingsItem(BaseDataModel):
+class SettingsItem(BaseDataModel, ActionMixin):
     name: str
     value: str | bool
 
-    action: DataActionEnum = DataActionEnum.SKIP
     coordinate: str | None = None
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Self:
         return cls(
-            name=data[constants.SETTINGS_SETTING],
-            value=data["value"],
-            coordinate=data["coordinate"],
+            action=data[constants.SETTINGS_ACTION]["value"],
+            name=data[constants.SETTINGS_SETTING]["value"],
+            coordinate=data[constants.SETTINGS_SETTING]["coordinate"],
+            value=data[constants.SETTINGS_VALUE]["value"],
         )
 
     @classmethod
@@ -59,12 +59,7 @@ class SettingsData(BaseDataModel):
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Self:
-        items = []
-        for key, item in data.items():
-            item.update({constants.SETTINGS_SETTING: key})
-            items.append(SettingsItem.from_dict(item))
-
-        return cls(items=items)
+        return cls(items=[SettingsItem.from_dict(data)])
 
     @classmethod
     def from_json(cls, data: dict[str, Any]) -> Self:
@@ -88,7 +83,7 @@ class SettingsData(BaseDataModel):
 
             settings = set_dict_value(settings, json_path, settings_value)
 
-        return settings
+        return {"settings": settings}
 
     def to_xlsx(self) -> dict[str, Any]:
         return {}

--- a/swo/mpt/cli/core/products/models/template.py
+++ b/swo/mpt/cli/core/products/models/template.py
@@ -6,17 +6,17 @@ from dateutil import parser
 from swo.mpt.cli.core.models import BaseDataModel
 from swo.mpt.cli.core.products import constants
 from swo.mpt.cli.core.products.models import DataActionEnum
+from swo.mpt.cli.core.products.models.mixins import ActionMixin
 
 
 @dataclass
-class TemplateData(BaseDataModel):
+class TemplateData(BaseDataModel, ActionMixin):
     id: str
     name: str
     type: str
     content: str
     default: bool
 
-    action: DataActionEnum = DataActionEnum.SKIP
     coordinate: str | None = None
     content_coordinate: str | None = None
     created_date: date | None = None

--- a/swo/mpt/cli/core/products/services/item_service.py
+++ b/swo/mpt/cli/core/products/services/item_service.py
@@ -1,71 +1,27 @@
+from collections.abc import Callable
 from typing import Any, cast
 
-from swo.mpt.cli.core.errors import MPTAPIError
 from swo.mpt.cli.core.models import DataCollectionModel
 from swo.mpt.cli.core.models.data_model import DataModel
 from swo.mpt.cli.core.mpt.flows import search_uom_by_name
-from swo.mpt.cli.core.products.constants import TAB_ITEMS
-from swo.mpt.cli.core.products.models import ItemData
+from swo.mpt.cli.core.products.models import DataActionEnum, ItemActionEnum, ItemData
 from swo.mpt.cli.core.products.services.related_components_base_service import (
     RelatedComponentsBaseService,
 )
-from swo.mpt.cli.core.services.service_result import ServiceResult
 
 
 class ItemService(RelatedComponentsBaseService):
-    # TODO: move to RelatedComponentsBaseService
-    def update(self) -> ServiceResult:
-        """
-        Updates an existing item
+    def prepare_data_model_to_create(self, data_model: DataModel) -> DataModel:
+        data_model = super().prepare_data_model_to_create(data_model)
 
-        Returns:
-            ServiceResult: The result of the update operation
-        """
-        errors = []
-        for item in self.file_manager.read_data():
-            item.product_id = self.resource_id
-            if item.to_skip:
-                self.stats.add_skipped(TAB_ITEMS)
-                continue
+        item = cast(ItemData, data_model)
+        item.unit_id = search_uom_by_name(self.api.client, item.unit_name).id
+        self.file_manager.write_id(item.unit_coordinate, item.unit_id)
 
-            try:
-                if item.to_update:
-                    try:
-                        params = {
-                            "externalIds.vendor": item.vendor_id,
-                            "product.id": item.product_id,
-                            "limit": 1,
-                        }
-                        item_data = self.api.list(params=params)["data"][0]
-                    except MPTAPIError as e:
-                        errors.append(str(e))
-                        self._set_error(str(e), item.id)
-                        continue
+        item.item_type = "operations" if self.account.is_operations() else "vendor"
+        item.product_id = self.resource_id
 
-                    item.id = item_data["id"]
-                    self.api.update(item.id, item.to_json())
-
-                elif item.to_create:
-                    item.unit_id = search_uom_by_name(self.api.client, item.unit_name).id
-                    item.type = "operations" if self.account.is_operations() else "vendor"
-                    try:
-                        new_item = self.api.post(json=item.to_json())
-                    except MPTAPIError as e:
-                        errors.append(str(e))
-                        self._set_error(str(e), item.id)
-                        continue
-
-                    item.id = new_item["id"]
-                else:
-                    self.api.post_action(item.id, item.action)
-            except Exception as e:
-                errors.append(str(e))
-                self._set_error(str(e), item.id)
-                continue
-
-            self._set_synced(item.id, item.coordinate)
-
-        return ServiceResult(success=len(errors) == 0, errors=errors, model=None, stats=self.stats)
+        return data_model
 
     def set_new_item_groups(self, item_groups: DataCollectionModel | None) -> None:
         """
@@ -93,14 +49,40 @@ class ItemService(RelatedComponentsBaseService):
         params.update({"product.id": self.resource_id})
         return params
 
-    def prepare_data_model_to_create(self, data_model: DataModel) -> DataModel:
-        data_model = super().prepare_data_model_to_create(data_model)
-
+    def _action_create_item(self, data_model: DataModel):
         item = cast(ItemData, data_model)
+
         item.unit_id = search_uom_by_name(self.api.client, item.unit_name).id
-        self.file_manager.write_id(item.unit_coordinate, item.unit_id)
-
         item.item_type = "operations" if self.account.is_operations() else "vendor"
-        item.product_id = self.resource_id
 
-        return data_model
+        super()._action_create_item(data_model)
+
+    def _action_post_action_item(self, data_model: DataModel) -> None:
+        """
+        Perform an action on the given data model.
+
+        Args:
+            data_model: The data model to perform the action on.
+
+        """
+        item = cast(ItemData, data_model)
+        self.api.post_action(item.id, item.action)
+
+    def _action_update_item(self, data_model: DataModel) -> None:
+        item = cast(ItemData, data_model)
+
+        params = {
+            "externalIds.vendor": item.vendor_id,
+            "product.id": item.product_id,
+            "limit": 1,
+        }
+        item_data = self.api.list(params=params)["data"][0]
+        item.id = item_data["id"]
+
+        super()._action_update_item(data_model)
+
+    def _get_update_action_handler(self, model_action: DataActionEnum) -> Callable:
+        if model_action in (ItemActionEnum.REVIEW, ItemActionEnum.PUBLISH):
+            return self._action_post_action_item
+
+        return super()._get_update_action_handler(model_action)

--- a/swo/mpt/cli/core/products/services/related_components_base_service.py
+++ b/swo/mpt/cli/core/products/services/related_components_base_service.py
@@ -1,10 +1,15 @@
+import logging
 from abc import ABC
+from collections.abc import Callable
 
 from swo.mpt.cli.core.errors import MPTAPIError
 from swo.mpt.cli.core.models import DataCollectionModel
 from swo.mpt.cli.core.models.data_model import DataModel
+from swo.mpt.cli.core.products.models import DataActionEnum
 from swo.mpt.cli.core.services import RelatedBaseService
 from swo.mpt.cli.core.services.service_result import ServiceResult
+
+logger = logging.getLogger(__name__)
 
 
 class RelatedComponentsBaseService(RelatedBaseService, ABC):
@@ -67,10 +72,31 @@ class RelatedComponentsBaseService(RelatedBaseService, ABC):
             stats=self.stats,
         )
 
-    def update(self) -> ServiceResult:  # pragma: no cover
-        return ServiceResult(
-            success=False, errors=["Updated method not implemented"], model=None, stats=self.stats
-        )
+    def update(self) -> ServiceResult:
+        errors = []
+        for data_model in self.file_manager.read_data():
+            data_model.product_id = self.resource_id
+            if data_model.to_skip:
+                self._set_skipped()
+                continue
+
+            try:
+                action_handler = self._get_update_action_handler(data_model.action)
+            except ValueError as e:
+                errors.append(str(e))
+                self._set_error(str(e), data_model.id)
+                continue
+
+            try:
+                action_handler(data_model)
+            except MPTAPIError as e:
+                errors.append(str(e))
+                self._set_error(str(e), data_model.id)
+                continue
+
+            self._set_synced(data_model.id, data_model.coordinate)
+
+        return ServiceResult(success=len(errors) == 0, errors=errors, model=None, stats=self.stats)
 
     def prepare_data_model_to_create(self, data_model: DataModel) -> DataModel:
         """
@@ -84,3 +110,67 @@ class RelatedComponentsBaseService(RelatedBaseService, ABC):
              DataModel: The data model to create
         """
         return data_model
+
+    def _action_create_item(self, data_model: DataModel):
+        """
+        Creates the item in the API. This method could be overridden by subclasses to customize
+        the data model before sending to API.
+
+        Args:
+            data_model: The data model to be created
+
+        """
+        new_data_model = self.api.post(data_model.to_json())
+        data_model.id = new_data_model["id"]  # type: ignore[attr-defined]
+
+    def _action_delete_item(self, data_model: DataModel) -> None:
+        """
+        Delete the item in the API. This method could be overridden by subclasses to customize
+        the data model before sending to API.
+
+        Args:
+            data_model: The data model to be deleted
+
+        """
+        logger.debug("Delete action is not supported yet")
+
+    def _action_update_item(self, data_model: DataModel) -> None:
+        """
+        Update the item in the API. This method could be overridden by subclasses to customize the
+        data model before sending to API.
+
+        Args:
+            data_model: The data model to be updated
+
+        Returns:
+
+        """
+        self.api.update(data_model.id, data_model.to_json())  # type: ignore[attr-defined]
+
+    def _get_update_action_handler(self, model_action: DataActionEnum) -> Callable:
+        """
+        Retrieve the appropriate action handler based onf the action type. This method could be
+        overridden by subclasses to add specific actions in subclasses.
+
+        Args:
+            model_action: The action type to retrieve the handler for.
+
+        Returns:
+            Callable: The action handler for the given action type.
+
+        Raises:
+            ValueError: If the action type is not supported.
+
+        """
+        if model_action == DataActionEnum.CREATE:
+            return self._action_create_item
+
+        if model_action == DataActionEnum.DELETE:
+            # TODO: uncomment once the delete action is supported
+            # return self._action_delete_item
+            raise ValueError(f"Action type {model_action} is not supported")
+
+        if model_action == DataActionEnum.UPDATE:
+            return self._action_update_item
+
+        raise ValueError(f"Invalid action: {model_action}")

--- a/tests/test_swo/test_mpt/test_cli/test_core/test_products/conftest.py
+++ b/tests/test_swo/test_mpt/test_cli/test_core/test_products/conftest.py
@@ -78,6 +78,8 @@ from swo.mpt.cli.core.products.constants import (
 from swo.mpt.cli.core.products.containers import ProductContainer
 from swo.mpt.cli.core.products.models import (
     AgreementParametersData,
+    DataActionEnum,
+    ItemActionEnum,
     ItemData,
     ItemGroupData,
     ParameterGroupData,
@@ -85,7 +87,6 @@ from swo.mpt.cli.core.products.models import (
     SettingsData,
     TemplateData,
 )
-from swo.mpt.cli.core.products.models.items import ItemAction
 from swo.mpt.cli.core.products.models.product import SettingsItem
 from swo.mpt.cli.core.products.services import (
     ItemGroupService,
@@ -169,7 +170,16 @@ def product_data_from_dict():
         created_date=datetime(2024, 1, 1, 0, 0),
         updated_date=datetime(2024, 1, 1, 0, 0),
         coordinate="B3",
-        settings=SettingsData(items=[SettingsItem(name="Item selection validation", value="Off")]),
+        settings=SettingsData(
+            items=[
+                SettingsItem(name="Product ordering", action=DataActionEnum.SKIP, value="Off"),
+                SettingsItem(
+                    name="Change order validation (draft)",
+                    action=DataActionEnum.UPDATE,
+                    value="Enabled",
+                ),
+            ]
+        ),
     )
 
 
@@ -291,7 +301,7 @@ def item_data_from_dict():
         unit_coordinate="J38272",
         vendor_id="NAV12345",
         status="Published",
-        action=ItemAction.UPDATE,
+        action=ItemActionEnum.UPDATE,
         coordinate="A38272",
         item_type="vendor",
     )

--- a/tests/test_swo/test_mpt/test_cli/test_core/test_products/test_app.py
+++ b/tests/test_swo/test_mpt/test_cli/test_core/test_products/test_app.py
@@ -94,7 +94,7 @@ def test_sync_product_update(mocker, product_container_mock, product_data_from_d
         "retrieve",
         return_value=ServiceResult(success=True, model=product_data_from_dict, stats=Mock()),
     )
-    update_product = mocker.patch("swo.mpt.cli.core.products.app.update_product")
+    update_product_mock = mocker.patch("swo.mpt.cli.core.products.app.update_product")
 
     result = runner.invoke(
         app,
@@ -106,7 +106,7 @@ def test_sync_product_update(mocker, product_container_mock, product_data_from_d
     assert "Do you want to update product" in result.stdout
     validate_definition_mock.assert_called_once()
     retrieve_mock.assert_called_once()
-    update_product.assert_called_once()
+    update_product_mock.assert_called_once()
 
 
 def test_sync_product_update_error(mocker, product_container_mock, product_data_from_dict):
@@ -121,7 +121,7 @@ def test_sync_product_update_error(mocker, product_container_mock, product_data_
         "retrieve",
         return_value=ServiceResult(success=True, model=product_data_from_dict, stats=Mock()),
     )
-    update_product = mocker.patch("swo.mpt.cli.core.products.app.update_product")
+    update_product_mock = mocker.patch("swo.mpt.cli.core.products.app.update_product")
 
     result = runner.invoke(
         app,
@@ -132,7 +132,7 @@ def test_sync_product_update_error(mocker, product_container_mock, product_data_
     assert result.exit_code == 3, result.stdout
     validate_definition_mock.assert_called_once()
     retrieve_mock.assert_called_once()
-    update_product.assert_called_once()
+    update_product_mock.assert_called_once()
 
 
 def test_sync_product_force_create(
@@ -354,14 +354,13 @@ def test_export_product_overwrites_existing_files(
     product_container_mock.product_service().export.assert_called_once()
 
 
-def test_update_product(mocker, product_container_mock, item_data_from_dict):
-    stats = ProductStatsCollector()
-    update_item_service_mock = mocker.patch.object(
-        product_container_mock.item_service(),
-        "update",
-        return_value=ServiceResult(success=True, model=item_data_from_dict, stats=stats),
-    )
-
+def test_update_product(product_container_mock):
     update_product(product_container_mock, Mock())
 
-    update_item_service_mock.assert_called_once()
+    product_container_mock.item_service().update.assert_called_once()
+    product_container_mock.item_group_service().update.assert_called_once()
+    product_container_mock.template_service().update.assert_called_once()
+    product_container_mock.parameter_group_service().update.assert_called_once()
+    product_container_mock.agreement_parameters_service().update.assert_called_once()
+    product_container_mock.request_parameters_service().update.assert_called_once()
+    product_container_mock.subscription_parameters_service().update.assert_called_once()

--- a/tests/test_swo/test_mpt/test_cli/test_core/test_products/test_models/test_items.py
+++ b/tests/test_swo/test_mpt/test_cli/test_core/test_products/test_models/test_items.py
@@ -1,6 +1,5 @@
 import pytest
-from swo.mpt.cli.core.products.models import ItemData
-from swo.mpt.cli.core.products.models.items import ItemAction
+from swo.mpt.cli.core.products.models import ItemActionEnum, ItemData
 
 
 def test_item_data_from_dict(item_file_data):
@@ -43,13 +42,13 @@ def test_item_data_to_json(item_data_from_dict):
 @pytest.mark.parametrize(
     ("action", "attr"),
     [
-        (ItemAction.CREATE, "to_create"),
-        (ItemAction.PUBLISH, "to_publish"),
-        (ItemAction.REVIEW, "to_review"),
-        (ItemAction.SKIP, "to_skip"),
-        (ItemAction.SKIPPED, "to_skip"),
-        (ItemAction.UNPUBLISH, "to_unpublish"),
-        (ItemAction.UPDATE, "to_update"),
+        (ItemActionEnum.CREATE, "to_create"),
+        (ItemActionEnum.PUBLISH, "to_publish"),
+        (ItemActionEnum.REVIEW, "to_review"),
+        (ItemActionEnum.SKIP, "to_skip"),
+        (ItemActionEnum.SKIPPED, "to_skip"),
+        (ItemActionEnum.UNPUBLISH, "to_unpublish"),
+        (ItemActionEnum.UPDATE, "to_update"),
     ],
 )
 def test_item_to_create(action, attr, item_data_from_dict):

--- a/tests/test_swo/test_mpt/test_cli/test_core/test_products/test_models/test_product.py
+++ b/tests/test_swo/test_mpt/test_cli/test_core/test_products/test_models/test_product.py
@@ -99,7 +99,11 @@ def test_product_to_xlsx(product_data_from_json):
 
 def test_settings_data_from_dict(settings_file_data):
     result = SettingsData.from_dict(
-        {"Change order validation (draft)": {"value": "Enabled", "coordinate": "C2"}}
+        {
+            SETTINGS_SETTING: {"value": "Change order validation (draft)", "coordinate": "A2"},
+            SETTINGS_ACTION: {"value": DataActionEnum.SKIP, "coordinate": "B2"},
+            SETTINGS_VALUE: {"value": "Enabled", "coordinate": "C2"},
+        }
     )
 
     assert len(result.items) == 1
@@ -107,7 +111,7 @@ def test_settings_data_from_dict(settings_file_data):
     assert isinstance(item, SettingsItem)
     assert item.name == "Change order validation (draft)"
     assert item.value == "Enabled"
-    assert item.coordinate == "C2"
+    assert item.coordinate == "A2"
     assert result.json_path is None
 
 
@@ -122,18 +126,27 @@ def test_settings_data_from_json(mpt_product_data):
 def test_settings_data_to_xlsx(product_data_from_dict):
     result = product_data_from_dict.settings.to_json()
 
-    assert result == {"itemSelection": False}
+    assert result == {
+        "settings": {
+            "productOrdering": False,
+            "preValidation": {"changeOrderDraft": True},
+        }
+    }
 
 
 def test_setting_item_from_dict(settings_file_data):
     result = SettingsItem.from_dict(
-        {SETTINGS_SETTING: "Purchase order validation (query)", "value": "Off", "coordinate": "A10"}
+        {
+            SETTINGS_SETTING: {"value": "Purchase order validation (query)", "coordinate": "A10"},
+            SETTINGS_ACTION: {"value": DataActionEnum.DELETE, "coordinate": "B10"},
+            SETTINGS_VALUE: {"value": "Off", "coordinate": "C10"},
+        }
     )
 
     assert result.name == "Purchase order validation (query)"
     assert result.value == "Off"
     assert result.coordinate == "A10"
-    assert result.action == DataActionEnum.SKIP
+    assert result.action == DataActionEnum.DELETE
 
 
 def test_setting_item_from_json(mpt_product_data):


### PR DESCRIPTION
Added handling of related components actions (create, update, etc.) to the update flow.

### Changes
* Added an update method for the related components and the sync command
* Extracted action logic into `ActionMixin` and `ItemActionMixin`
* Integrated related components actions into the update workflow

### Notes
This iteration does not include the delete action. It will be added in a separate PR due to its complexity.