### PR TITLE
MPT-12042: a price list cannot be sync if modified column is null

### DIFF
--- a/swo/mpt/cli/core/price_lists/models/item.py
+++ b/swo/mpt/cli/core/price_lists/models/item.py
@@ -82,7 +82,6 @@ class ItemData(BaseDataModel):
             unit_pp=data[constants.PRICELIST_ITEMS_UNIT_PP]["value"],
             unit_sp=data.get(constants.PRICELIST_ITEMS_UNIT_SP, {}).get("value"),
             vendor_id=data[constants.PRICELIST_ITEMS_ITEM_VENDOR_ID]["value"],
-            modified_date=data[constants.PRICELIST_ITEMS_MODIFIED]["value"].date(),
             action=ItemAction(data[constants.PRICELIST_ITEMS_ACTION]["value"]),
             type=data.get("type"),
         )

--- a/tests/tests/mpt/cli/core/price_lists/models/test_item.py
+++ b/tests/tests/mpt/cli/core/price_lists/models/test_item.py
@@ -1,5 +1,3 @@
-from datetime import date
-
 from swo.mpt.cli.core.price_lists.models.item import ItemAction, ItemData, ItemStatus
 
 
@@ -26,7 +24,6 @@ def test_item_data_from_dict(item_file_data):
     assert result.unit_sp is None
     assert result.vendor_id == "AO03.25842.MN"
     assert result.action == ItemAction.UPDATE
-    assert result.modified_date == date(2025, 5, 23)
     assert result.type is None
 
 


### PR DESCRIPTION
Remove the modified property from the from_dict method, as it’s not needed