### PR TITLE
MPT-12174: all parameters are exported as Agreements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,9 @@ filterwarnings = [
     "ignore:Support for class-based `config` is deprecated:DeprecationWarning",
     "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
 ]
+markers = [
+  "integration: marks test as integration tests",
+]
 
 [tool.coverage.run]
 branch = true

--- a/swo/mpt/cli/core/products/containers.py
+++ b/swo/mpt/cli/core/products/containers.py
@@ -26,8 +26,11 @@ from swo.mpt.cli.core.products.models import (
     AgreementParametersData,
     ItemData,
     ItemGroupData,
+    ItemParametersData,
     ParameterGroupData,
     ProductData,
+    RequestParametersData,
+    SubscriptionParametersData,
     TemplateData,
 )
 from swo.mpt.cli.core.products.services import (
@@ -117,17 +120,17 @@ class ProductContainer(containers.DeclarativeContainer):
         },
         "item_parameters": {
             "api": _apis.provided["parameters"],
-            "data_model": AgreementParametersData,
+            "data_model": ItemParametersData,
             "file_manager": _file_managers.provided["item_parameters"],
         },
         "request_parameters": {
             "api": _apis.provided["parameters"],
-            "data_model": AgreementParametersData,
+            "data_model": RequestParametersData,
             "file_manager": _file_managers.provided["request_parameters"],
         },
         "subscription_parameters": {
             "api": _apis.provided["parameters"],
-            "data_model": AgreementParametersData,
+            "data_model": SubscriptionParametersData,
             "file_manager": _file_managers.provided["subscription_parameters"],
         },
         "template": {

--- a/tests/tests/mpt/cli/core/products/conftest.py
+++ b/tests/tests/mpt/cli/core/products/conftest.py
@@ -1,10 +1,11 @@
 import shutil
 from datetime import datetime
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 from freezegun import freeze_time
+from requests import Response
 from swo.mpt.cli.core.products.constants import (
     GENERAL_ACCOUNT_ID,
     GENERAL_ACCOUNT_NAME,
@@ -370,7 +371,7 @@ def item_group_data_from_json(mpt_item_group_data):
 @pytest.fixture
 def item_group_data_from_dict():
     return ItemGroupData(
-        id="IGR-0400-9557-0002",
+        id="IGR-0232-2541-0002",
         coordinate="J2",
         name="Items",
         label="Select items",
@@ -456,14 +457,14 @@ def parameters_file_data():
 
 
 @pytest.fixture
-def parameters_data_from_json(mpt_parameters_data):
-    return AgreementParametersData.from_json(mpt_parameters_data)
+def parameters_data_from_json(mpt_agreement_parameter_data):
+    return AgreementParametersData.from_json(mpt_agreement_parameter_data)
 
 
 @pytest.fixture
 def parameters_data_from_dict():
     return AgreementParametersData(
-        id="PAR-9939-6700-0001",
+        id="PAR-0232-2541-0001",
         coordinate="K234",
         name="Agreement type",
         external_id="agreementType",
@@ -473,7 +474,7 @@ def parameters_data_from_dict():
         "to create a new Adobe VIP Marketplace account or migrate your existing Adobe "
         "VIP account to Adobe VIP Marketplace.",
         display_order=101,
-        group_id="PGR-9939-6700-0001",
+        group_id="PGR-0232-2541-0001",
         options={
             "optionsList": [
                 {
@@ -509,7 +510,7 @@ def parameters_data_from_dict():
 
 
 @pytest.fixture
-def mpt_parameters_data():
+def mpt_agreement_parameter_data():
     return {
         "id": "PAR-0232-2541-0001",
         "name": "Agreement type",
@@ -585,6 +586,102 @@ def mpt_parameters_data():
 
 
 @pytest.fixture
+def mpt_item_parameter_data():
+    return {
+        "id": "PAR-0232-2541-0022",
+        "constraints": {"required": False},
+        "context": "None",
+        "description": "offer type",
+        "displayOrder": 100,
+        "externalId": "offer_type",
+        "name": "OFFER_TYPE",
+        "options": {"hintText": "OFFER_TYPE", "pattern": "", "placeholderText": "OFFER_TYPE"},
+        "phase": "Configuration",
+        "product": {
+            "externalIds": {},
+            "icon": "/v1/catalog/products/PRD-5516-5707/icon",
+            "id": "PRD-5516-5707",
+            "name": "SV Adobe VIP Marketplace for Commercial",
+            "status": "Published",
+        },
+        "scope": "Item",
+        "status": "Active",
+        "type": "SingleLineText",
+        "audit": {
+            "created": {
+                "at": "2025-04-17T15:16:42.098Z",
+                "by": {"id": "TKN-9352-9507", "name": "User9352-9507"},
+            }
+        },
+    }
+
+
+@pytest.fixture
+def mpt_request_parameter_data():
+    return {
+        "id": "PAR-0232-2541-0012",
+        "name": "Contact Parameter",
+        "description": "Contact parameter",
+        "scope": "Request",
+        "phase": "Order",
+        "context": "None",
+        "displayOrder": 200,
+        "constraints": {"readonly": False, "required": False},
+        "product": {
+            "externalIds": {},
+            "icon": "/v1/catalog/products/PRD-5516-5707/icon",
+            "id": "PRD-5516-5707",
+            "name": "SV Adobe VIP Marketplace for Commercial",
+            "status": "Published",
+        },
+        "options": {"phoneMandatory": False, "defaultValue": "None", "hintText": "Contact details"},
+        "type": "Contact",
+        "status": "Active",
+        "audit": {
+            "created": {
+                "at": "2025-04-17T15:16:42.098Z",
+                "by": {"id": "TKN-9352-9507", "name": "User9352-9507"},
+            }
+        },
+    }
+
+
+@pytest.fixture
+def mpt_subscription_parameter_data():
+    return {
+        "id": "PAR-0232-2541-0023",
+        "constraints": {"required": True},
+        "context": "None",
+        "description": "Store the full Adobe SKU (with discount level) of the item included in a "
+        "subscription.",
+        "displayOrder": 2001,
+        "externalId": "adobeSKU",
+        "name": "Subscription SKU",
+        "options": {
+            "hintText": "Subscription SKU",
+            "placeholderText": "Store the full Adobe SKU (with discount level)",
+        },
+        "phase": "Fulfillment",
+        "product": {
+            "externalIds": {},
+            "icon": "/v1/catalog/products/PRD-5516-5707/icon",
+            "id": "PRD-5516-5707",
+            "name": "SV Adobe VIP Marketplace for Commercial",
+            "status": "Published",
+        },
+        "scope": "Subscription",
+        "status": "Active",
+        "type": "SingleLineText",
+        "audit": {
+            "created": {
+                "at": "2025-04-17T15:16:42.098Z",
+                "by": {"id": "TKN-9352-9507", "name": "User9352-9507"},
+            }
+        },
+    }
+
+
+@pytest.fixture
 def parameter_group_file_data():
     return {
         PARAMETERS_GROUPS_ID: {"value": "IGR-3114-5854-0002", "coordinate": "A325"},
@@ -602,7 +699,7 @@ def parameter_group_file_data():
 @pytest.fixture
 def parameter_group_data_from_dict():
     return ParameterGroupData(
-        id="PGR-9939-6700-0001",
+        id="PGR-0232-2541-0001",
         coordinate="A2",
         name="Agreement",
         label="Create agreement",
@@ -655,7 +752,7 @@ def mpt_parameter_group_data():
 @pytest.fixture
 def template_file_data():
     return {
-        TEMPLATES_ID: {"value": "TPL-0400-9557-0005", "coordinate": "A3"},
+        TEMPLATES_ID: {"value": "TPL-0232-2541-0005", "coordinate": "A3"},
         TEMPLATES_NAME: {"value": "BulkMigrate", "coordinate": "B3"},
         TEMPLATES_ACTION: {"value": "-", "coordinate": "C3"},
         TEMPLATES_TYPE: {"value": "OrderCompleted", "coordinate": "D3"},
@@ -677,7 +774,7 @@ def template_data_from_json(mpt_template_data):
 @pytest.fixture
 def template_data_from_dict():
     return TemplateData(
-        id="TPL-0400-9557-0005",
+        id="TPL-0232-2541-0005",
         coordinate="A2",
         name="Change",
         type="OrderCompleted",
@@ -752,3 +849,12 @@ def settings_file_data():
         "Purchase order validation (query)": {"value": "Off", "coordinate": "C11"},
         "Termination order validation (draft)": {"value": "Off", "coordinate": "C12"},
     }
+
+
+@pytest.fixture
+def list_response_mock_data_factory():
+    def _create_data_response(data):
+        response = {"$meta": {"pagination": {"offset": 0, "limit": 100, "total": 0}}, "data": data}
+        return Mock(spec=Response, json=Mock(return_value=response))
+
+    return _create_data_response

--- a/tests/tests/mpt/cli/core/products/models/test_parameters.py
+++ b/tests/tests/mpt/cli/core/products/models/test_parameters.py
@@ -48,8 +48,8 @@ def test_parameters_data_from_dict(parameters_file_data):
     assert result.group_id_coordinate == "I325"
 
 
-def test_parameters_data_from_json(mpt_parameters_data):
-    result = AgreementParametersData.from_json(mpt_parameters_data)
+def test_parameters_data_from_json(mpt_agreement_parameter_data):
+    result = AgreementParametersData.from_json(mpt_agreement_parameter_data)
 
     assert result.id == "PAR-0232-2541-0001"
     assert (
@@ -146,7 +146,7 @@ def test_parameters_data_to_json(parameters_data_from_dict):
         "constraints": {"hidden": False, "readonly": False, "optional": True, "required": False},
         "externalId": "agreementType",
         "displayOrder": 101,
-        "group": {"id": "PGR-9939-6700-0001"},
+        "group": {"id": "PGR-0232-2541-0001"},
     }
     assert result["options"].get("label") is None
 
@@ -193,7 +193,7 @@ def test_parameters_data_to_xlsx(parameters_data_from_json):
 
 
 @pytest.mark.parametrize(
-    ("is_order_request", "expected_result"), [(True, {"id": "PGR-9939-6700-0001"}), (False, None)]
+    ("is_order_request", "expected_result"), [(True, {"id": "PGR-0232-2541-0001"}), (False, None)]
 )
 def test_group_property(is_order_request, expected_result, mocker, parameters_data_from_dict):
     mocker.patch.object(

--- a/tests/tests/mpt/cli/core/products/models/test_template.py
+++ b/tests/tests/mpt/cli/core/products/models/test_template.py
@@ -16,7 +16,7 @@ from swo.mpt.cli.core.products.models import DataActionEnum, TemplateData
 def test_template_data_from_dict(template_file_data):
     result = TemplateData.from_dict(template_file_data)
 
-    assert result.id == "TPL-0400-9557-0005"
+    assert result.id == "TPL-0232-2541-0005"
     assert result.coordinate == "A3"
     assert result.action == "-"
     assert result.name == "BulkMigrate"

--- a/tests/tests/mpt/cli/core/products/services/test_related_components_base_service.py
+++ b/tests/tests/mpt/cli/core/products/services/test_related_components_base_service.py
@@ -58,7 +58,7 @@ def service_context(active_vendor_account):
     )
 
 
-def test_create(mocker, service_context, mpt_parameters_data):
+def test_create(mocker, service_context, mpt_agreement_parameter_data):
     data_model_mock = FakeDataModel()
     new_item_mock = {"id": "new_fake_id"}
     mocker.patch.object(service_context.file_manager, "read_data", return_value=[data_model_mock])
@@ -99,7 +99,7 @@ def test_create_api_error(mocker, service_context, parameters_data_from_dict):
     add_error_mock.assert_called_once_with("fake_tab_name")
 
 
-def test_export(mocker, service_context, mpt_parameters_data):
+def test_export(mocker, service_context, mpt_agreement_parameter_data):
     create_data_mock = mocker.patch.object(service_context.file_manager, "create_tab")
     data = {"meta": {"offset": 0, "limit": 100, "total": 0}, "data": []}
     api_list_mock = mocker.patch.object(service_context.api, "list", return_value=data)
@@ -115,7 +115,7 @@ def test_export(mocker, service_context, mpt_parameters_data):
     add_mock.assert_called_once()
 
 
-def test_export_error(mocker, service_context, mpt_parameters_data):
+def test_export_error(mocker, service_context, mpt_agreement_parameter_data):
     create_data_mock = mocker.patch.object(service_context.file_manager, "create_tab")
     api_list_mock = mocker.patch.object(
         service_context.api,

--- a/tests/tests/mpt/cli/core/products/test_app.py
+++ b/tests/tests/mpt/cli/core/products/test_app.py
@@ -2,6 +2,9 @@ from pathlib import Path
 from unittest.mock import Mock
 from urllib.parse import urljoin
 
+import pytest
+from openpyxl.reader.excel import load_workbook
+from requests import Response
 from swo.mpt.cli.core.models import DataCollectionModel
 from swo.mpt.cli.core.products import app
 from swo.mpt.cli.core.products.app import create_product, update_product
@@ -297,24 +300,6 @@ def test_create_product_error(mocker, product_container_mock):
     create_item_group_spy.assert_not_called()
 
 
-def test_export_product(mocker, tmp_path, account_container_mock, product_container_mock):
-    product_id = "fake_product_id"
-    out_path = tmp_path / product_id
-
-    result = runner.invoke(app, ["export", product_id, "--out", str(out_path)], input="y\n")
-
-    assert result.exit_code == 0, result.stdout
-    product_container_mock.product_service().export.assert_called_once()
-    product_container_mock.item_service().export.assert_called_once()
-    product_container_mock.item_group_service().export.assert_called_once()
-    product_container_mock.parameter_group_service().export.assert_called_once()
-    product_container_mock.agreement_parameters_service().export.assert_called_once()
-    product_container_mock.item_parameters_service().export.assert_called_once()
-    product_container_mock.request_parameters_service().export.assert_called_once()
-    product_container_mock.subscription_parameters_service().export.assert_called_once()
-    product_container_mock.template_service().export.assert_called_once()
-
-
 def test_export_product_account_not_allowed(account_container_mock, active_vendor_account):
     account_container_mock.account.override(active_vendor_account)
 
@@ -365,3 +350,112 @@ def test_update_product(product_container_mock):
     product_container_mock.agreement_parameters_service().update.assert_called_once()
     product_container_mock.request_parameters_service().update.assert_called_once()
     product_container_mock.subscription_parameters_service().update.assert_called_once()
+
+
+@pytest.mark.integration
+def test_export_product(
+    mocker,
+    tmp_path,
+    account_container_mock,
+    list_response_mock_data_factory,
+    mpt_product_data,
+    mpt_item_data,
+    mpt_item_group_data,
+    mpt_parameter_group_data,
+    mpt_agreement_parameter_data,
+    mpt_item_parameter_data,
+    mpt_request_parameter_data,
+    mpt_subscription_parameter_data,
+    mpt_template_data,
+):
+    mocker.patch.object(
+        account_container_mock.mpt_client(),
+        "get",
+        side_effect=[
+            Mock(spec=Response, json=Mock(return_value=mpt_product_data)),
+            list_response_mock_data_factory([mpt_item_data]),
+            list_response_mock_data_factory([mpt_item_group_data]),
+            list_response_mock_data_factory([mpt_parameter_group_data]),
+            list_response_mock_data_factory([mpt_agreement_parameter_data]),
+            list_response_mock_data_factory([mpt_item_parameter_data]),
+            list_response_mock_data_factory([mpt_request_parameter_data]),
+            list_response_mock_data_factory([mpt_subscription_parameter_data]),
+            list_response_mock_data_factory([mpt_template_data]),
+        ],
+    )
+
+    product_id = "PRD-0232-2541"
+    result = runner.invoke(app, ["export", product_id, "--out", str(tmp_path)], input="y\ny\n")
+
+    assert result.exit_code == 0, result.stdout
+    product_path = tmp_path / f"{product_id}.xlsx"
+    assert product_path.exists()
+    wb = load_workbook(product_path)
+
+    expected_sheets = [
+        "General",
+        "Settings",
+        "Items",
+        "Items Groups",
+        "Parameters Groups",
+        "Agreements Parameters",
+        "Item Parameters",
+        "Request Parameters",
+        "Subscription Parameters",
+        "Templates",
+    ]
+    assert wb.sheetnames == expected_sheets
+
+    general_sheet = wb["General"]
+    assert general_sheet.max_row == 12
+    assert general_sheet["A1"].value == "General Information"
+    assert general_sheet["A2"].value == "Product ID"
+    assert general_sheet["B2"].value == product_id
+
+    settings_sheet = wb["Settings"]
+    assert settings_sheet.max_row == 12
+    assert settings_sheet["A1"].value == "Setting"
+    assert settings_sheet["A2"].value == "Change order validation (draft)"
+    assert settings_sheet["C2"].value == "Enabled"
+
+    items_sheet = wb["Items"]
+    assert items_sheet.max_row == 2
+    assert items_sheet["A1"].value == "ID"
+    assert items_sheet["A2"].value == "ITM-0232-2541-0001"
+
+    items_groups_sheet = wb["Items Groups"]
+    assert items_groups_sheet.max_row == 2
+    assert items_groups_sheet["A1"].value == "ID"
+    assert items_groups_sheet["A2"].value == "IGR-0232-2541-0001"
+
+    parameters_groups_sheet = wb["Parameters Groups"]
+    assert parameters_groups_sheet.max_row == 2
+    assert parameters_groups_sheet["A1"].value == "ID"
+    assert parameters_groups_sheet["A2"].value == "PGR-0232-2541-0002"
+
+    agreements_params_sheet = wb["Agreements Parameters"]
+    assert agreements_params_sheet.max_row == 2
+    assert agreements_params_sheet["A1"].value == "ID"
+    assert agreements_params_sheet["A2"].value == "PAR-0232-2541-0001"
+
+    item_params_sheet = wb["Item Parameters"]
+    assert item_params_sheet.max_row == 2
+    assert item_params_sheet["A1"].value == "ID"
+    assert item_params_sheet["A2"].value == "PAR-0232-2541-0022"
+
+    request_params_sheet = wb["Request Parameters"]
+    assert request_params_sheet.max_row == 2
+    assert request_params_sheet["A1"].value == "ID"
+    assert request_params_sheet["A2"].value == "PAR-0232-2541-0012"
+
+    subscription_parameter_sheet = wb["Subscription Parameters"]
+    assert subscription_parameter_sheet.max_row == 2
+    assert subscription_parameter_sheet["A1"].value == "ID"
+    assert subscription_parameter_sheet["A2"].value == "PAR-0232-2541-0023"
+
+    templates_sheet = wb["Templates"]
+    assert templates_sheet.max_row == 2
+    assert templates_sheet["A1"].value == "ID"
+    assert templates_sheet["A2"].value == "TPL-0232-2541-0005"
+
+    wb.close()


### PR DESCRIPTION
Item, request and subscription parameters are exported as Agreements

### Changes

* Fixed data_model property in the container for  item, request and subscription parameters
* Added export integration test