### PR TITLE
MPT-12232: change write_id by write_ids to allow write ids in bulk

### DIFF
--- a/cli/core/handlers/file_manager.py
+++ b/cli/core/handlers/file_manager.py
@@ -1,6 +1,7 @@
 import re
 from abc import ABC, abstractmethod
 from pathlib import Path
+from typing import Any
 
 from cli.core.handlers.excel_file_handler import ExcelFileHandler
 from openpyxl.worksheet.datavalidation import DataValidation
@@ -35,15 +36,15 @@ class ExcelFileManager(ABC):
         """
         raise NotImplementedError
 
-    def write_id(self, coordinate: str, new_id: str) -> None:
+    def write_ids(self, data: dict[str, Any]) -> None:
         """
-        Writes a new ID value to the specified cell coordinate in the managed sheet.
+        Writes the IDs into the managed sheet.
 
         Args:
-            coordinate: The cell coordinate (e.g., 'A1') to write the ID to.
-            new_id: The ID value to write.
+            data: A dict where each key is a cell coordinate (e.g., 'A1') as each value is
+            the corresponding ID.
         """
-        self.file_handler.write([{self._sheet_name: {coordinate: new_id}}])
+        self.file_handler.write([{self._sheet_name: data}])
 
     @staticmethod
     def _get_row_and_column_from_coordinate(coordinate: str) -> tuple[str, int]:

--- a/cli/core/products/services/item_service.py
+++ b/cli/core/products/services/item_service.py
@@ -16,7 +16,7 @@ class ItemService(RelatedComponentsBaseService):
 
         item = cast(ItemData, data_model)
         item.unit_id = search_uom_by_name(self.api.client, item.unit_name).id
-        self.file_manager.write_id(item.unit_coordinate, item.unit_id)
+        self.file_manager.write_ids({item.unit_coordinate: item.unit_id})
 
         item.item_type = "operations" if self.account.is_operations() else "vendor"
         item.product_id = self.resource_id
@@ -34,13 +34,17 @@ class ItemService(RelatedComponentsBaseService):
         if item_groups is None or not item_groups.collection:
             return None
 
+        new_ids = {}
         for item in self.file_manager.read_data():
             try:
                 new_group = item_groups.retrieve_by_id(item.group_id)
             except KeyError:
                 continue
 
-            self.file_manager.write_id(item.group_coordinate, new_group.id)
+            new_ids[item.group_coordinate] = new_group.id
+
+        if new_ids:
+            self.file_manager.write_ids(new_ids)
 
         return None
 

--- a/cli/core/products/services/parameters_service.py
+++ b/cli/core/products/services/parameters_service.py
@@ -18,13 +18,17 @@ class ParametersService(RelatedComponentsBaseService):
         if parameter_groups is None or not parameter_groups.collection:
             return None
 
+        new_ids = {}
         for data_model in self.file_manager.read_data():
             try:
                 new_group = parameter_groups.retrieve_by_id(data_model.group_id)
             except KeyError:
                 continue
 
-            self.file_manager.write_id(data_model.group_id_coordinate, new_group.id)
+            new_ids[data_model.group_id_coordinate] = new_group.id
+
+        if new_ids:
+            self.file_manager.write_ids(new_ids)
 
         return None
 

--- a/cli/core/products/services/template_service.py
+++ b/cli/core/products/services/template_service.py
@@ -16,6 +16,7 @@ class TemplateService(RelatedComponentsBaseService):
         if param_groups is None or not param_groups.collection:
             return None
 
+        new_ids = {}
         for data_model in self.file_manager.read_data():
             content = data_model.content
 
@@ -24,6 +25,9 @@ class TemplateService(RelatedComponentsBaseService):
                     continue
 
                 content = content.replace(id, item.id)
-                self.file_manager.write_id(data_model.content_coordinate, content)
+                new_ids[data_model.content_coordinate] = content
+
+        if new_ids:
+            self.file_manager.write_ids(new_ids)
 
         return None

--- a/cli/core/services/base_service.py
+++ b/cli/core/services/base_service.py
@@ -75,7 +75,7 @@ class Service(ABC):
         self.stats.add_error(self.file_manager.tab_name)
 
     def _set_synced(self, resource_id: str, item_coordinate: str) -> None:
-        self.file_manager.write_id(item_coordinate, resource_id)
+        self.file_manager.write_ids({item_coordinate: resource_id})
         self.stats.add_synced(self.file_manager.tab_name)
 
     def _set_skipped(self):

--- a/tests/cli/core/handlers/test_excel_file_manager.py
+++ b/tests/cli/core/handlers/test_excel_file_manager.py
@@ -25,10 +25,10 @@ def test_get_row_and_column_from_coordinate_invalid():
         FakeExcelFileManager._get_row_and_column_from_coordinate("")
 
 
-def test_write_id(mocker):
+def test_write_ids(mocker):
     file_handler_spy = mocker.patch.object(ExcelFileHandler, "write")
     file_manager = FakeExcelFileManager("/tmp/fake.xlsx")
 
-    file_manager.write_id("A1", "12345")
+    file_manager.write_ids({"A1": "12345"})
 
     file_handler_spy.assert_called_once_with([{file_manager._sheet_name: {"A1": "12345"}}])

--- a/tests/cli/core/price_lists/services/test_item_service.py
+++ b/tests/cli/core/price_lists/services/test_item_service.py
@@ -90,7 +90,7 @@ def test_update_item(mocker, service_context, mpt_item_data, item_data_from_dict
         service_context.file_manager, "read_data", return_value=[item_data_from_dict]
     )
     mocker.patch.object(service_context.api, "list", return_value={"data": [mpt_item_data]})
-    file_handler_write_mock = mocker.patch.object(service_context.file_manager, "write_id")
+    write_ids_mock = mocker.patch.object(service_context.file_manager, "write_ids")
     update_mock = mocker.patch.object(service_context.api, "update", return_value=mpt_item_data)
     stats_spy = mocker.spy(service_context.stats, "add_synced")
     service = ItemService(service_context)
@@ -101,9 +101,7 @@ def test_update_item(mocker, service_context, mpt_item_data, item_data_from_dict
     assert result.model is None
     assert service_context.stats.tabs["Price Items"]["synced"] == 1
     update_mock.assert_called_once()
-    file_handler_write_mock.assert_called_once_with(
-        item_data_from_dict.coordinate, item_data_from_dict.id
-    )
+    write_ids_mock.assert_called_once_with({item_data_from_dict.coordinate: item_data_from_dict.id})
     stats_spy.assert_called_once_with(TAB_PRICE_ITEMS)
 
 
@@ -151,7 +149,7 @@ def test_update_item_skip(mocker, service_context, mpt_item_data, item_data_from
         service_context.file_manager, "read_data", return_value=[item_data_from_json]
     )
     mocker.patch.object(item_data_from_json, "to_update", return_value=False)
-    file_handler_write_mock = mocker.patch.object(service_context.file_manager, "write_id")
+    write_ids_mock = mocker.spy(service_context.file_manager, "write_ids")
     api_update_spy = mocker.spy(service_context.api, "update")
     stats_spy = mocker.spy(service_context.stats, "add_skipped")
     service = ItemService(service_context)
@@ -159,6 +157,6 @@ def test_update_item_skip(mocker, service_context, mpt_item_data, item_data_from
     result = service.update()
 
     assert result.success is True
-    file_handler_write_mock.assert_not_called()
+    write_ids_mock.assert_not_called()
     api_update_spy.assert_not_called()
     stats_spy.assert_called_once_with(TAB_PRICE_ITEMS)

--- a/tests/cli/core/price_lists/services/test_pricelist_service.py
+++ b/tests/cli/core/price_lists/services/test_pricelist_service.py
@@ -30,7 +30,7 @@ def test_create_price_list(mocker, service_context, mpt_price_list_data, price_l
         "post",
         return_value=mpt_price_list_data,
     )
-    file_handler_write_mock = mocker.patch.object(service_context.file_manager, "write_id")
+    write_ids_mock = mocker.patch.object(service_context.file_manager, "write_ids")
     stats_spy = mocker.spy(service_context.stats, "add_synced")
     service = PriceListService(service_context)
 
@@ -39,7 +39,7 @@ def test_create_price_list(mocker, service_context, mpt_price_list_data, price_l
     assert result.success is True
     read_data_mock.assert_called_once()
     stats_spy.assert_called_once_with(TAB_GENERAL)
-    file_handler_write_mock.assert_called_once_with("B3", price_list_data_from_dict.id)
+    write_ids_mock.assert_called_once_with({"B3": price_list_data_from_dict.id})
     api_post_mock.assert_called_once()
 
 

--- a/tests/cli/core/products/services/test_item_service.py
+++ b/tests/cli/core/products/services/test_item_service.py
@@ -33,7 +33,7 @@ def test_update_item_create(mocker, service_context, item_data_from_dict, mpt_it
         "cli.core.products.services.item_service.search_uom_by_name",
         return_value=Mock(id="fake_unit_id"),
     )
-    file_handler_write_mock = mocker.patch.object(service_context.file_manager, "write_id")
+    write_ids_mock = mocker.patch.object(service_context.file_manager, "write_ids")
     update_spy = mocker.spy(service_context.api, "update")
     stats_spy = mocker.spy(service_context.stats, "add_synced")
     service = ItemService(service_context)
@@ -45,9 +45,7 @@ def test_update_item_create(mocker, service_context, item_data_from_dict, mpt_it
     assert service_context.stats.tabs["Items"]["synced"] == 1
     search_uom_by_name_mock.assert_called_once()
     post_mock.assert_called_once()
-    file_handler_write_mock.assert_called_once_with(
-        item_data_from_dict.coordinate, mpt_item_data["id"]
-    )
+    write_ids_mock.assert_called_once_with({item_data_from_dict.coordinate: mpt_item_data["id"]})
     update_spy.assert_not_called()
     stats_spy.assert_called_once_with(TAB_ITEMS)
 
@@ -102,7 +100,7 @@ def test_update_item_publish(mocker, service_context, item_data_from_dict, mpt_i
         service_context.file_manager, "read_data", return_value=[item_data_from_dict]
     )
     post_action_mock = mocker.patch.object(service_context.api, "post_action")
-    write_id_mock = mocker.patch.object(service_context.file_manager, "write_id")
+    write_ids_mock = mocker.patch.object(service_context.file_manager, "write_ids")
     stats_spy = mocker.spy(service_context.stats, "add_synced")
     service = ItemService(service_context)
 
@@ -112,7 +110,7 @@ def test_update_item_publish(mocker, service_context, item_data_from_dict, mpt_i
     assert result.model is None
     assert service_context.stats.tabs["Items"]["synced"] == 1
     post_action_mock.assert_called_once_with(item_data_from_dict.id, ItemActionEnum.PUBLISH)
-    write_id_mock.assert_called_once_with(item_data_from_dict.coordinate, item_data_from_dict.id)
+    write_ids_mock.assert_called_once_with({item_data_from_dict.coordinate: item_data_from_dict.id})
     stats_spy.assert_called_once_with(TAB_ITEMS)
 
 
@@ -124,14 +122,14 @@ def test_set_new_item_groups(
     )
     param_group = DataCollectionModel(collection={"old_group_id": item_group_data_from_dict})
     item_data_from_dict.group_id = "old_group_id"
-    write_id_mock = mocker.patch.object(service_context.file_manager, "write_id")
+    write_ids_mock = mocker.patch.object(service_context.file_manager, "write_ids")
     service = ItemService(service_context)
 
     service.set_new_item_groups(param_group)
 
     read_data_mock.assert_called_once()
-    write_id_mock.assert_called_once_with(
-        item_data_from_dict.group_coordinate, item_group_data_from_dict.id
+    write_ids_mock.assert_called_once_with(
+        {item_data_from_dict.group_coordinate: item_group_data_from_dict.id}
     )
 
 
@@ -142,24 +140,24 @@ def test_set_new_item_groups_error(
         service_context.file_manager, "read_data", return_value=[item_data_from_dict]
     )
     param_group = DataCollectionModel(collection={"not_found_it": item_group_data_from_dict})
-    write_id_mock = mocker.patch.object(service_context.file_manager, "write_id")
+    write_ids_spy = mocker.spy(service_context.file_manager, "write_ids")
     service = ItemService(service_context)
 
     service.set_new_item_groups(param_group)
 
     read_data_mock.assert_called_once()
-    write_id_mock.assert_not_called()
+    write_ids_spy.assert_not_called()
 
 
 def test_set_new_parameter_groups_empty(mocker, service_context):
     read_data_spy = mocker.spy(service_context.file_manager, "read_data")
-    write_id_spy = mocker.spy(service_context.file_manager, "write_id")
+    write_ids_spy = mocker.spy(service_context.file_manager, "write_ids")
     service = ItemService(service_context)
 
     service.set_new_item_groups(DataCollectionModel(collection={}))
 
     read_data_spy.assert_not_called()
-    write_id_spy.assert_not_called()
+    write_ids_spy.assert_not_called()
 
 
 def test_set_export_params(service_context, item_data_from_dict):
@@ -175,7 +173,7 @@ def test_prepare_data_model_to_create(mocker, service_context, item_data_from_di
         "cli.core.products.services.item_service.search_uom_by_name",
         return_value=Mock(id="fake_unit_id"),
     )
-    write_id_mock = mocker.patch.object(service_context.file_manager, "write_id")
+    write_ids_mock = mocker.patch.object(service_context.file_manager, "write_ids")
     service = ItemService(service_context)
 
     data_model = service.prepare_data_model_to_create(item_data_from_dict)
@@ -184,4 +182,4 @@ def test_prepare_data_model_to_create(mocker, service_context, item_data_from_di
     assert data_model.item_type == "vendor"
     assert data_model.product_id == "test-product-id"
     search_uom_by_name_mock.assert_called_once()
-    write_id_mock.assert_called_once_with(item_data_from_dict.unit_coordinate, "fake_unit_id")
+    write_ids_mock.assert_called_once_with({item_data_from_dict.unit_coordinate: "fake_unit_id"})

--- a/tests/cli/core/products/services/test_parameters_service.py
+++ b/tests/cli/core/products/services/test_parameters_service.py
@@ -27,14 +27,14 @@ def test_set_new_parameter_groups(
     )
     param_group = DataCollectionModel(collection={"old_group_id": parameter_group_data_from_dict})
     parameters_data_from_dict.group_id = "old_group_id"
-    write_id_mock = mocker.patch.object(service_context.file_manager, "write_id")
+    write_ids_mock = mocker.patch.object(service_context.file_manager, "write_ids")
     service = ParametersService(service_context)
 
     service.set_new_parameter_group(param_group)
 
     read_data_mock.assert_called_once()
-    write_id_mock.assert_called_once_with(
-        parameters_data_from_dict.group_id_coordinate, parameter_group_data_from_dict.id
+    write_ids_mock.assert_called_once_with(
+        {parameters_data_from_dict.group_id_coordinate: parameter_group_data_from_dict.id}
     )
 
 
@@ -45,24 +45,24 @@ def test_set_new_parameter_groups_error(
         service_context.file_manager, "read_data", return_value=[parameters_data_from_dict]
     )
     param_group = DataCollectionModel(collection={"not_found_key": parameter_group_data_from_dict})
-    write_id_mock = mocker.patch.object(service_context.file_manager, "write_id")
+    write_ids_spy = mocker.spy(service_context.file_manager, "write_ids")
     service = ParametersService(service_context)
 
     service.set_new_parameter_group(param_group)
 
     read_data_mock.assert_called_once()
-    write_id_mock.assert_not_called()
+    write_ids_spy.assert_not_called()
 
 
 def test_set_new_parameter_groups_empty(mocker, service_context):
     read_data_spy = mocker.spy(service_context.file_manager, "read_data")
-    write_id_spy = mocker.spy(service_context.file_manager, "write_id")
+    write_ids_spy = mocker.spy(service_context.file_manager, "write_ids")
     service = ParametersService(service_context)
 
     service.set_new_parameter_group(DataCollectionModel(collection={}))
 
     read_data_spy.assert_not_called()
-    write_id_spy.assert_not_called()
+    write_ids_spy.assert_not_called()
 
 
 def test_set_export_params(service_context, parameters_data_from_dict):

--- a/tests/cli/core/products/services/test_product_service.py
+++ b/tests/cli/core/products/services/test_product_service.py
@@ -31,7 +31,7 @@ def test_create(mocker, service_context, mpt_product_data, product_data_from_dic
     )
     api_post_mock = mocker.patch.object(service_context.api, "post", return_value=mpt_product_data)
     api_update_mock = mocker.patch.object(service_context.api, "update")
-    file_handler_write_mock = mocker.patch.object(service_context.file_manager, "write_id")
+    write_id_mock = mocker.patch.object(service_context.file_manager, "write_ids")
     stats_spy = mocker.spy(service_context.stats, "add_synced")
     service = ProductService(service_context)
 
@@ -40,7 +40,7 @@ def test_create(mocker, service_context, mpt_product_data, product_data_from_dic
     assert result.success is True
     read_data_mock.assert_called_once()
     stats_spy.assert_called_once_with(TAB_GENERAL)
-    file_handler_write_mock.assert_called_once_with("B3", product_data_from_dict.id)
+    write_id_mock.assert_called_once_with({"B3": product_data_from_dict.id})
     api_post_mock.assert_called_once()
     api_update_mock.assert_called_once()
 

--- a/tests/cli/core/products/services/test_related_components_base_service.py
+++ b/tests/cli/core/products/services/test_related_components_base_service.py
@@ -63,7 +63,7 @@ def test_create(mocker, service_context, mpt_agreement_parameter_data):
     new_item_mock = {"id": "new_fake_id"}
     mocker.patch.object(service_context.file_manager, "read_data", return_value=[data_model_mock])
     post_mock = mocker.patch.object(service_context.api, "post", return_value=new_item_mock)
-    file_handler_write_id_mock = mocker.patch.object(service_context.file_manager, "write_id")
+    write_ids_mock = mocker.patch.object(service_context.file_manager, "write_ids")
     stats_mock = mocker.patch.object(service_context.stats, "add_synced")
     service = FakeRelatedComponentsService(service_context)
     prepare_data_model_to_create_spy = mocker.spy(service, "prepare_data_model_to_create")
@@ -73,7 +73,7 @@ def test_create(mocker, service_context, mpt_agreement_parameter_data):
     assert result.success is True
     assert result.model is None
     assert isinstance(result.collection, DataCollectionModel)
-    file_handler_write_id_mock.assert_called_once_with("fake_coordinate", "new_fake_id")
+    write_ids_mock.assert_called_once_with({"fake_coordinate": "new_fake_id"})
     post_mock.assert_called_once_with(json={"id": "fake_id"})
     stats_mock.assert_called_once_with("fake_tab_name")
     prepare_data_model_to_create_spy.assert_called_once()
@@ -162,7 +162,7 @@ def test_update_action_create(mocker, service_context):
         return_value=[FakeDataModel(id="create_id", action=DataActionEnum.CREATE)],
     )
     mocker.patch.object(FakeDataModel, "to_skip", False)
-    file_handler_write_mock = mocker.patch.object(service_context.file_manager, "write_id")
+    write_ids_mock = mocker.patch.object(service_context.file_manager, "write_ids")
     stats_synced_mock = mocker.patch.object(service_context.stats, "add_synced")
     api_post_mock = mocker.patch.object(
         service_context.api, "post", return_value={"id": "new_fake_id"}
@@ -173,7 +173,7 @@ def test_update_action_create(mocker, service_context):
 
     assert result.success is True
     assert result.model is None
-    file_handler_write_mock.assert_called_once_with("fake_coordinate", "new_fake_id")
+    write_ids_mock.assert_called_once_with({"fake_coordinate": "new_fake_id"})
     stats_synced_mock.assert_called_once_with("fake_tab_name")
     api_post_mock.assert_called_once_with({"id": "create_id"})
 
@@ -206,7 +206,7 @@ def test_update_action_update(mocker, service_context):
     )
     mocker.patch.object(FakeDataModel, "to_skip", False)
 
-    file_handler_write_mock = mocker.patch.object(service_context.file_manager, "write_id")
+    write_ids_mock = mocker.patch.object(service_context.file_manager, "write_ids")
     stats_synced_mock = mocker.patch.object(service_context.stats, "add_synced")
     api_update_mock = mocker.patch.object(service_context.api, "update")
     service = FakeRelatedComponentsService(service_context)
@@ -215,7 +215,7 @@ def test_update_action_update(mocker, service_context):
 
     assert result.success is True
     assert result.model is None
-    file_handler_write_mock.assert_called_once_with("fake_coordinate", "update_id")
+    write_ids_mock.assert_called_once_with({"fake_coordinate": "update_id"})
     stats_synced_mock.assert_called_once_with("fake_tab_name")
     api_update_mock.assert_called_once_with("update_id", {"id": "update_id"})
 

--- a/tests/cli/core/products/services/test_template_service.py
+++ b/tests/cli/core/products/services/test_template_service.py
@@ -29,23 +29,23 @@ def test_set_new_parameter_group(
         collection={"old_param_id": parameter_group_data_from_dict, "no_id": None}
     )
     template_data_from_dict.content = "old_param_id: bla"
-    write_id_mock = mocker.patch.object(service_context.file_manager, "write_id")
+    write_ids_mock = mocker.patch.object(service_context.file_manager, "write_ids")
     service = TemplateService(service_context)
 
     service.set_new_parameter_group(param_group)
 
     read_data_mock.assert_called_once()
-    write_id_mock.assert_called_once_with(
-        template_data_from_dict.content_coordinate, f"{parameter_group_data_from_dict.id}: bla"
+    write_ids_mock.assert_called_once_with(
+        {template_data_from_dict.content_coordinate: f"{parameter_group_data_from_dict.id}: bla"}
     )
 
 
 def test_set_new_parameter_groups_empty(mocker, service_context):
     read_data_spy = mocker.spy(service_context.file_manager, "read_data")
-    write_id_spy = mocker.spy(service_context.file_manager, "write_id")
+    write_ids_spy = mocker.spy(service_context.file_manager, "write_ids")
     service = TemplateService(service_context)
 
     service.set_new_parameter_group(DataCollectionModel(collection={}))
 
     read_data_spy.assert_not_called()
-    write_id_spy.assert_not_called()
+    write_ids_spy.assert_not_called()


### PR DESCRIPTION
A small improvement changing the `write_id` method by `write_ids` method to allow writing the ids in bulk. This improve the performance for create and update flows, as we avoid calling the save method for each id individually, which is very expensive from a timing point of view.

