### PR TITLE
MPT-12416: remove unnecessary mypy overrides

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,11 +140,7 @@ explicit_package_bases = true
 
 [[tool.mypy.overrides]]
 module = [
-  "click.*",
-  "dependency_injector.*",
   "gunicorn.*",
   "pyfiglet.*",
-  "typer.*",
-  "rich.*"
 ]
 ignore_missing_imports = true


### PR DESCRIPTION
Remove unnecessary mypy overrides.

<img width="1106" height="278" alt="image" src="https://github.com/user-attachments/assets/c98bc43f-168e-42d8-9bce-91cc3a3518fb" />

<img width="1233" height="148" alt="image" src="https://github.com/user-attachments/assets/24865800-5b01-4eb2-b2cd-b85b1502e65d" />
