### PR TITLE
[BACKPORT] MPT-12550: set external_id fields as optional

### DIFF
--- a/swo/mpt/cli/core/mpt/models.py
+++ b/swo/mpt/cli/core/mpt/models.py
@@ -1,4 +1,4 @@
-from typing import Annotated, TypeAlias, TypeVar
+from typing import TypeAlias, TypeVar
 
 from pydantic import BaseModel, Field
 
@@ -44,8 +44,8 @@ class ItemGroup(BaseModel):
 
 class Parameter(BaseModel):
     id: str
+    external_id: str | None = Field(default=None, alias="externalId")
     name: str
-    external_id: Annotated[str, Field(alias="externalId")]
 
 
 class Item(BaseModel):


### PR DESCRIPTION
Set external_id (parameter model) optional to handle API responses where they are not present in the JSON response