### PR TITLE
fix: remove incorrect .json() call on dict in price list item service

### DIFF
--- a/cli/core/price_lists/services/item_service.py
+++ b/cli/core/price_lists/services/item_service.py
@@ -57,7 +57,7 @@ class ItemService(RelatedBaseService):
         except MPTAPIError as error:
             return ServiceResult(success=False, errors=[str(error)], model=None, stats=self.stats)
 
-        item_model = self.data_model.from_json(response.json())
+        item_model = self.data_model.from_json(response)
         return ServiceResult(success=True, model=item_model, stats=self.stats)
 
     @override

--- a/tests/cli/core/price_lists/services/test_item_service.py
+++ b/tests/cli/core/price_lists/services/test_item_service.py
@@ -7,8 +7,6 @@ from cli.core.price_lists.models import ItemData
 from cli.core.price_lists.services import ItemService
 from cli.core.services.service_context import ServiceContext
 from cli.core.stats import PriceListStatsCollector
-from requests import Response
-
 
 @pytest.fixture
 def service_context(
@@ -57,7 +55,7 @@ def test_retrieve_from_mpt(mocker, service_context, mpt_item_data, item_data_fro
     api_get_mock = mocker.patch.object(
         service_context.api,
         "get",
-        return_value=mocker.Mock(spec=Response, json=mocker.Mock(return_value=mpt_item_data)),
+        return_value=mpt_item_data,
     )
     service = ItemService(service_context)
 


### PR DESCRIPTION
## Summary

`ItemService.retrieve_from_mpt` was calling `response.json()` on the value returned by `self.api.get()`. However, `APIService.get()` already returns a `dict` (via `.to_dict()` on the `mpt-api-client` resource), so calling `.json()` on it raises `AttributeError` at runtime.

This is a leftover pattern from the old HTTP client (`cli/core/mpt/client.py`, removed in #168), where `response` was an HTTP `Response` object with a `.json()` method.

## Changes

- `cli/core/price_lists/services/item_service.py`: changed `response.json()` → `response`
- `tests/cli/core/price_lists/services/test_item_service.py`: updated mock to return a plain dict instead of a `Response` mock; removed unused `from requests import Response` import

## Testing

All 358 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixed an incorrect `.json()` call in the ItemService that was causing AttributeErrors when retrieving items from the MPT API.

### Changes

- **Fixed ItemService.retrieve_from_mpt**: Removed incorrect `.json()` call on the API response dict, as `APIService.get()` already returns a parsed dictionary (not an HTTP response object)
- **Updated test mocks**: Modified `test_retrieve_from_mpt` to return a plain dict instead of mocking a Response object with a `.json()` method
- **Removed unused import**: Cleaned up unnecessary `requests.Response` import from tests

### Testing

All 358 tests pass successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->