### PR TITLE
MPT-17825: Resolve WPS335 fix iter types

### DIFF
--- a/cli/plugins/audit_plugin/audit_records.py
+++ b/cli/plugins/audit_plugin/audit_records.py
@@ -35,7 +35,7 @@ def format_json_path(path: str, source_trail: dict[str, Any], target_trail: dict
     base_path, index_str = array_path.split("[")
     index = int(index_str)
 
-    for trail in [source_trail, target_trail]:
+    for trail in (source_trail, target_trail):
         current_node: Any | None = trail
         for part in base_path.split("."):
             if not isinstance(current_node, dict) or part not in current_node:

--- a/tests/cli/core/accounts/test_app.py
+++ b/tests/cli/core/accounts/test_app.py
@@ -351,7 +351,7 @@ def test_list_accounts(new_accounts_path, mocker):
     result = runner.invoke(app, ["list"])
 
     assert result.exit_code == 0, result.stdout
-    assert all((account in result.stdout) for account in ["ACC-12341", "ACC-12342"]), result.stdout
+    assert all((account in result.stdout) for account in ("ACC-12341", "ACC-12342")), result.stdout
 
 
 def test_list_active_account(new_accounts_path, mocker):

--- a/tests/cli/core/test_error_wrappers.py
+++ b/tests/cli/core/test_error_wrappers.py
@@ -14,6 +14,11 @@ def error_factory():
     return _build_runtime_error
 
 
+@pytest.fixture
+def http_error_callable(mocker):
+    return mocker.Mock(side_effect=MPTHttpError(500, "err", "boom"))
+
+
 def test_http_wrapper_get_from_class(error_factory):
     wrapper = HttpErrorWrapper(lambda *_args, **_kwargs: None, error_factory)
 
@@ -39,9 +44,9 @@ def test_api_wrapper_get_from_instance(error_factory):
     assert result() == "bound"
 
 
-def test_api_wrapper_raises_factory_error(error_factory):
+def test_api_wrapper_raises_factory_error(error_factory, http_error_callable):
     wrapper = ApiErrorWrapper(
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(MPTHttpError(500, "err", "boom")),
+        http_error_callable,
         error_factory,
     )
 


### PR DESCRIPTION
🤖 **Codex-generated PR** — Please review carefully.

## Summary
- remove `WPS335` from the flake8 ignore list
- replace incorrect iterables used only to satisfy control flow in production and tests
- keep behavior unchanged while satisfying wemake loop-iterator rules

## Validation
- `make check`
- `make check-all`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-17825](https://softwareone.atlassian.net/browse/MPT-17825)

- Replace list iterables with tuples in `format_json_path` method in `cli/plugins/audit_plugin/audit_records.py` to comply with WPS335 wemake Python Style Guide rules
- Update assertion in `test_list_accounts` to use tuple literal instead of list literal for membership checks
- Add `http_error_callable` pytest fixture in `tests/cli/core/test_error_wrappers.py` and refactor `test_api_wrapper_raises_factory_error` to use the fixture instead of inline callable
- Remove WPS335 from flake8 ignore list while maintaining existing behavior and test coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-17825]: https://softwareone.atlassian.net/browse/MPT-17825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ