### PR TITLE
MPT-20363 mpt-cli product export fails if product item group descript…

### DIFF
--- a/cli/core/products/models/item_group.py
+++ b/cli/core/products/models/item_group.py
@@ -14,7 +14,6 @@ class ItemGroupData(BaseDataModel, ActionMixin):
 
     id: str
     default: bool
-    description: str
     display_order: int
     label: str
     multiple: bool
@@ -23,6 +22,7 @@ class ItemGroupData(BaseDataModel, ActionMixin):
 
     coordinate: str | None = None
     created_date: dt.date | None = None
+    description: str | None = None
     updated_date: dt.date | None = None
 
     @classmethod
@@ -48,7 +48,7 @@ class ItemGroupData(BaseDataModel, ActionMixin):
             id=json_data["id"],
             name=json_data["name"],
             label=json_data["label"],
-            description=json_data["description"],
+            description=json_data.get("description"),
             display_order=json_data["displayOrder"],
             default=json_data["default"],
             multiple=json_data["multiple"],


### PR DESCRIPTION
…ion is empty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-20363](https://softwareone.atlassian.net/browse/MPT-20363)

- Made `ItemGroupData.description` optional by changing its type from `str` to `str | None`
- Updated `from_json` method to safely handle missing `description` field using `.get()` instead of direct dictionary access, preventing KeyError exceptions during product export when the description is empty

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-20363]: https://softwareone.atlassian.net/browse/MPT-20363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ