### PR TITLE
MPT-17825: Narrow WPS ignore scope

### DIFF
--- a/cli/core/file_discovery.py
+++ b/cli/core/file_discovery.py
@@ -1,4 +1,3 @@
-from glob import glob
 from pathlib import Path
 
 
@@ -12,15 +11,15 @@ def get_files_path(files_path: list[str]) -> list[str]:
         List of .xlsx file paths found in the given paths.
 
     """
-    file_paths = []
+    file_paths: list[Path] = []
 
     for file_path in files_path:
         path = Path(file_path)
         if path.is_file():
-            file_paths.append(file_path)
+            file_paths.append(path)
         elif path.is_dir():
-            file_paths.extend(glob(str(path / "*")))  # noqa: PTH207
+            file_paths.extend(path.glob("*"))
         else:
-            file_paths.extend(glob(file_path))  # noqa: PTH207
+            file_paths.extend(path.parent.glob(path.name))
 
-    return [path_entry for path_entry in file_paths if path_entry.endswith(".xlsx")]
+    return [str(path_entry) for path_entry in file_paths if path_entry.suffix == ".xlsx"]

--- a/cli/core/stats.py
+++ b/cli/core/stats.py
@@ -111,28 +111,17 @@ class ProductStatsCollector(StatsCollector):
     """Statistics collector specifically for product synchronization operations."""
 
     def __init__(self) -> None:
-        general: TabResults = default_results()
-        parameters_groups: TabResults = default_results()
-        items_groups: TabResults = default_results()
-        agreements_parameters: TabResults = default_results()
-        asset_parameters: TabResults = default_results()
-        item_parameters: TabResults = default_results()
-        request_parameters: TabResults = default_results()
-        subscription_parameters: TabResults = default_results()
-        item_rows: TabResults = default_results()
-        templates: TabResults = default_results()
-
         tabs = {
-            "General": general,
-            "Parameters Groups": parameters_groups,
-            "Items Groups": items_groups,
-            "Agreements Parameters": agreements_parameters,
-            "Assets Parameters": asset_parameters,
-            "Item Parameters": item_parameters,
-            "Request Parameters": request_parameters,
-            "Subscription Parameters": subscription_parameters,
-            "Items": item_rows,
-            "Templates": templates,
+            "General": default_results(),
+            "Parameters Groups": default_results(),
+            "Items Groups": default_results(),
+            "Agreements Parameters": default_results(),
+            "Assets Parameters": default_results(),
+            "Item Parameters": default_results(),
+            "Request Parameters": default_results(),
+            "Subscription Parameters": default_results(),
+            "Items": default_results(),
+            "Templates": default_results(),
         }
 
         super().__init__(tabs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,26 @@ select = ["AAA", "E999", "WPS"]
 show-source = true
 statistics = false
 per-file-ignores = [
-  "*.py:WPS210,WPS213,WPS221,WPS231,WPS432",
+  "cli/core/accounts/app.py:WPS210",
+  "cli/core/console/renderers/audit.py:WPS210",
+  "cli/core/console/renderers/banner.py:WPS210,WPS221",
+  "cli/core/handlers/excel_file_handler_mixins.py:WPS210,WPS221",
+  "cli/core/handlers/horizontal_tab_file_manager.py:WPS210",
+  "cli/core/handlers/vertical_tab_file_manager.py:WPS221",
+  "cli/core/mpt/api.py:WPS210,WPS221",
+  "cli/core/nested_dicts.py:WPS221",
+  "cli/core/price_lists/app/export.py:WPS210,WPS213,WPS231",
+  "cli/core/price_lists/app/sync.py:WPS210,WPS231",
+  "cli/core/price_lists/services/item_service.py:WPS210,WPS221,WPS231",
+  "cli/core/price_lists/services/price_list_service.py:WPS221",
+  "cli/core/products/app.py:WPS210,WPS213,WPS231",
+  "cli/core/products/models/product.py:WPS210",
+  "cli/core/products/services/product_service.py:WPS221",
+  "cli/core/products/services/related_components_base_service.py:WPS210,WPS221,WPS231",
+  "cli/core/stats.py:WPS210",
+  "cli/plugins/audit_plugin/api.py:WPS210",
+  "cli/plugins/audit_plugin/app.py:WPS210",
+  "cli/plugins/audit_plugin/audit_records.py:WPS210,WPS221,WPS231",
   "tests/**:WPS202,WPS204,WPS210,WPS213,WPS218,WPS221,WPS432"
 ]
 


### PR DESCRIPTION
🤖 **Codex-generated PR** — Please review carefully.

## Summary
- narrow the current WPS ignore scope from a broad `*.py` entry to explicit production files
- replace `glob`-based file discovery with `pathlib` traversal in file discovery
- simplify `ProductStatsCollector` tab initialization without changing behavior

## Validation
- `make check`
- `make check-all`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-17825](https://softwareone.atlassian.net/browse/MPT-17825)

- Narrow WPS (wemake-python-styleguide) ignore scope in pyproject.toml by replacing the broad "*.py" ignore with explicit per-file WPS ignore entries for specific production modules under cli/
- Replace glob-based file discovery with pathlib traversal in cli/core/file_discovery.py; get_files_path now works with Path objects and filters .xlsx files via Path.suffix
- Simplify ProductStatsCollector initialization in cli/core/stats.py by inlining TabResults instantiation for tabs without changing behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-17825]: https://softwareone.atlassian.net/browse/MPT-17825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ