### PR TITLE
MPT-17825: Split audit_records helpers into audit_paths module

### DIFF
--- a/cli/plugins/audit_plugin/audit_paths.py
+++ b/cli/plugins/audit_plugin/audit_paths.py
@@ -1,0 +1,53 @@
+from typing import Any
+
+type AuditTrail = dict[str, Any]
+
+
+def get_external_id(current_node: Any, index: int) -> str | None:
+    """Get the external ID from an object.
+
+    Args:
+        current_node: the object to get the external ID from.
+        index: the index of the object to get the external ID from.
+
+    Returns:
+        The external ID or ``None``.
+
+    """
+    if isinstance(current_node, list) and len(current_node) > index:
+        try:
+            return current_node[index]["externalId"]
+        except (IndexError, KeyError):
+            return None
+
+    return None
+
+
+def is_valid_path(path: str) -> bool:
+    """Check if a path is valid.
+
+    Args:
+        path: The path to check.
+
+    Returns:
+        ``True`` if the path is valid, ``False`` otherwise.
+
+    """
+    return "[" in path and "]" in path
+
+
+def parse_array_path(path: str) -> tuple[list[str], int]:
+    """Parse ``a.b.c[N]rest`` into ``(["a", "b", "c"], N)``."""
+    array_path = path.split("]", 1)[0]
+    base_path, index_str = array_path.split("[")
+    return base_path.split("."), int(index_str)
+
+
+def walk_trail(trail: AuditTrail, parts: list[str]) -> Any:
+    """Walk ``trail`` along ``parts``; return the last node or ``None`` if the path is invalid."""
+    current_node: Any | None = trail
+    for part in parts:
+        if not isinstance(current_node, dict) or part not in current_node:
+            return None
+        current_node = current_node[part]
+    return current_node

--- a/cli/plugins/audit_plugin/audit_records.py
+++ b/cli/plugins/audit_plugin/audit_records.py
@@ -2,10 +2,20 @@ from typing import Any
 
 from cli.core.console import console
 from cli.core.console.renderers.audit import AuditRecordsRenderer
-
-type AuditTrail = dict[str, Any]
+from cli.plugins.audit_plugin.audit_paths import (
+    AuditTrail,
+    get_external_id,
+    is_valid_path,
+    parse_array_path,
+    walk_trail,
+)
 
 audit_records_renderer = AuditRecordsRenderer()
+
+
+def display_audit_records(records: list) -> None:
+    """Display available audit records in a table format."""
+    console.print(audit_records_renderer.render(records))
 
 
 def flatten_dict(
@@ -18,13 +28,7 @@ def flatten_dict(
         if isinstance(node_value, dict):
             flattened_items.extend(flatten_dict(node_value, new_key, sep=sep).items())
         elif isinstance(node_value, list):
-            for index, list_entry in enumerate(node_value):
-                if isinstance(list_entry, dict):
-                    flattened_items.extend(
-                        flatten_dict(list_entry, f"{new_key}[{index}]", sep=sep).items()
-                    )
-                else:
-                    flattened_items.append((f"{new_key}[{index}]", list_entry))
+            flattened_items.extend(_flatten_list_entries(node_value, new_key, sep))
         else:
             flattened_items.append((new_key, node_value))
     return dict(flattened_items)
@@ -35,56 +39,22 @@ def format_json_path(path: str, source_trail: AuditTrail, target_trail: AuditTra
     if not is_valid_path(path):
         return path
 
-    array_path, _rest = path.split("]", 1)
-    base_path, index_str = array_path.split("[")
-    index = int(index_str)
-
+    parts, index = parse_array_path(path)
     for trail in (source_trail, target_trail):
-        current_node: Any | None = trail
-        for part in base_path.split("."):
-            if not isinstance(current_node, dict) or part not in current_node:
-                current_node = None
-                break
-            current_node = current_node[part]
-
-        external_id = get_external_id(current_node, index)
+        external_id = get_external_id(walk_trail(trail, parts), index)
         if external_id is not None:
             return f"{path} (externalId: {external_id})"
 
     return path
 
 
-def is_valid_path(path: str) -> bool:
-    """Check if a path is valid.
-
-    Args:
-        path: The path to check.
-
-    Returns: True if the path is valid, False otherwise.
-
-    """
-    return "[" in path and "]" in path
-
-
-def get_external_id(current_node: Any, index: int) -> str | None:
-    """Get the external ID from an object.
-
-    Args:
-        current_node: the object to get the external ID from.
-        index: the index of the object to get the external ID from.
-
-    Returns: the external ID or None.
-
-    """
-    if isinstance(current_node, list) and len(current_node) > index:
-        try:
-            return current_node[index]["externalId"]
-        except (IndexError, KeyError):
-            return None
-
-    return None
-
-
-def display_audit_records(records: list) -> None:
-    """Display available audit records in a table format."""
-    console.print(audit_records_renderer.render(records))
+def _flatten_list_entries(list_value: list, prefix: str, sep: str) -> list:
+    """Flatten the entries of a list, dispatching dict entries back to ``flatten_dict``."""
+    flattened: list = []
+    for index, list_entry in enumerate(list_value):
+        item_key = f"{prefix}[{index}]"
+        if isinstance(list_entry, dict):
+            flattened.extend(flatten_dict(list_entry, item_key, sep=sep).items())
+        else:
+            flattened.append((item_key, list_entry))
+    return flattened

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,6 @@ per-file-ignores = [
   "cli/core/stats.py:WPS210",
   "cli/plugins/audit_plugin/api.py:WPS210",
   "cli/plugins/audit_plugin/app.py:WPS210",
-  "cli/plugins/audit_plugin/audit_records.py:WPS210,WPS231",
   "tests/**:WPS202,WPS204,WPS210,WPS213,WPS218,WPS221,WPS432"
 ]
 

--- a/tests/cli/plugins/audit_plugin/test_audit_paths.py
+++ b/tests/cli/plugins/audit_plugin/test_audit_paths.py
@@ -1,0 +1,31 @@
+import pytest
+from cli.plugins.audit_plugin.audit_paths import get_external_id, is_valid_path
+
+
+@pytest.mark.parametrize(
+    ("source_node", "index", "expected_result"),
+    [
+        ([{"externalId": "EXT123", "value": "old"}], 0, "EXT123"),
+        ([{"key": "error"}], 0, None),
+        ([{"index": "error"}], 2, None),
+    ],
+)
+def test_get_external_id_path(source_node, index, expected_result):
+    result = get_external_id(source_node, index)
+
+    assert result == expected_result
+
+
+@pytest.mark.parametrize(
+    ("path", "expected_result"),
+    [
+        ("[ foo ]", True),
+        ("[ foo ", False),
+        (" foo ]", False),
+        ("bla", False),
+    ],
+)
+def test_is_valid_path(path, expected_result):
+    result = is_valid_path(path)
+
+    assert result == expected_result

--- a/tests/cli/plugins/audit_plugin/test_audit_records.py
+++ b/tests/cli/plugins/audit_plugin/test_audit_records.py
@@ -1,10 +1,9 @@
 import pytest
+from cli.plugins.audit_plugin.audit_paths import get_external_id, is_valid_path
 from cli.plugins.audit_plugin.audit_records import (
     display_audit_records,
     flatten_dict,
     format_json_path,
-    get_external_id,
-    is_valid_path,
 )
 
 

--- a/tests/cli/plugins/audit_plugin/test_audit_records.py
+++ b/tests/cli/plugins/audit_plugin/test_audit_records.py
@@ -1,5 +1,4 @@
 import pytest
-from cli.plugins.audit_plugin.audit_paths import get_external_id, is_valid_path
 from cli.plugins.audit_plugin.audit_records import (
     display_audit_records,
     flatten_dict,
@@ -42,35 +41,6 @@ def test_flatten_dict(input_dict, expected_result):
 )
 def test_format_json_path(path, source, target, expected_result):
     result = format_json_path(path, source, target)
-
-    assert result == expected_result
-
-
-@pytest.mark.parametrize(
-    ("source_node", "index", "expected_result"),
-    [
-        ([{"externalId": "EXT123", "value": "old"}], 0, "EXT123"),
-        ([{"key": "error"}], 0, None),
-        ([{"index": "error"}], 2, None),
-    ],
-)
-def test_get_external_id_path(source_node, index, expected_result):
-    result = get_external_id(source_node, index)
-
-    assert result == expected_result
-
-
-@pytest.mark.parametrize(
-    ("path", "expected_result"),
-    [
-        ("[ foo ]", True),
-        ("[ foo ", False),
-        (" foo ]", False),
-        ("bla", False),
-    ],
-)
-def test_is_valid_path(path, expected_result):
-    result = is_valid_path(path)
 
     assert result == expected_result
 


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## Summary
- Move the path/trail utilities of [`cli/plugins/audit_plugin/audit_records.py`](cli/plugins/audit_plugin/audit_records.py) into a new sibling module [`cli/plugins/audit_plugin/audit_paths.py`](cli/plugins/audit_plugin/audit_paths.py).
- Refactor \`flatten_dict\` and \`format_json_path\` so neither exceeds the wemake complexity / locals thresholds, eliminating the last \`WPS210\` and \`WPS231\` violations in the audit plugin.
- Drop the \`WPS210,WPS231\` entry for \`audit_records.py\` from \`[tool.flake8] per-file-ignores\`.

## Approach
- **New [`audit_paths.py`](cli/plugins/audit_plugin/audit_paths.py)** — hosts \`AuditTrail\` (the existing type alias), the two previously-public helpers (\`is_valid_path\`, \`get_external_id\`), and two new helpers extracted in this PR:
  - \`parse_array_path(path) -> (parts, index)\` — parses \`a.b.c[N]rest\` once, into a tuple ready for the trail walk.
  - \`walk_trail(trail, parts) -> Any\` — walks a trail along a dotted path and returns the leaf node (or \`None\` if any step is missing).
- **[`audit_records.py`](cli/plugins/audit_plugin/audit_records.py)**:
  - \`flatten_dict\` keeps its recursive shape but the list branch now delegates to a protected \`_flatten_list_entries\` helper that recurses back into \`flatten_dict\` for nested dicts. This collapses the inner loop / nesting that drove the WPS231 violation.
  - \`format_json_path\` becomes a flat dispatch: validate, parse, walk each trail, ask \`get_external_id\` for the lookup. WPS210 falls below threshold without a \`# noqa\`.
- **Module-split rationale**: \`audit_records.py\` was tipping over WPS202 (too many module members) after adding the helpers, even though \`flatten_dict\` and \`format_json_path\` were individually clean. Path/trail utilities form a coherent secondary concern and belong in their own module.
- **Tests**: only the import paths change — \`get_external_id\` and \`is_valid_path\` are still tested directly from the new module. Behaviour is identical.

## Validation
- \`uv run ruff format --check .\`
- \`uv run ruff check .\`
- \`uv run flake8 .\`
- \`uv run mypy .\`
- \`uv lock --check\`
- \`uv run pytest\` — 363 passed, 100% coverage on both \`audit_records.py\` and \`audit_paths.py\`

Closes [MPT-17825](https://softwareone.atlassian.net/browse/MPT-17825)

[MPT-17825]: https://softwareone.atlassian.net/browse/MPT-17825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-17825](https://softwareone.atlassian.net/browse/MPT-17825)

- Added new module cli/plugins/audit_plugin/audit_paths.py with AuditTrail type and helpers: is_valid_path(), get_external_id(), parse_array_path(), walk_trail()
- Refactored cli/plugins/audit_plugin/audit_records.py to import and use audit_paths utilities; removed duplicated path helpers and type alias
- Rewrote format_json_path() to validate, parse, walk trails, then call get_external_id() (flat dispatch)
- Refactored flatten_dict() to delegate list handling to a new _flatten_list_entries() helper to reduce complexity
- Removed per-file flake8 ignores for audit_records.py (addressed WPS210/WPS231 violations)
- Moved/updated tests: added tests/cli/plugins/audit_plugin/test_audit_paths.py and adjusted imports in test_audit_records.py
- Validation: ruff/flake8/mypy/pytest run — 363 tests passed; 100% coverage on audit_records.py and audit_paths.py

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softwareone-platform/swo-marketplace-cli/pull/212)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->