### PR TITLE
MPT-17825 remove production wemake ignores

### DIFF
--- a/cli/core/console/renderers/audit.py
+++ b/cli/core/console/renderers/audit.py
@@ -19,19 +19,13 @@ class AuditRecordsRenderer:
         table.add_column("Details", style="white")
 
         for idx, record in enumerate(records, 1):
-            timestamp = record.get("timestamp", "N/A")
-            audit_id = record.get("id", "N/A")
-            actor = self._get_actor(record)
-            event = record.get("event", "N/A")
-            details = record.get("details", "N/A")
-
             table.add_row(
                 str(idx),
-                timestamp,
-                audit_id,
-                actor,
-                event.replace("platform.commerce.", ""),
-                details,
+                record.get("timestamp", "N/A"),
+                record.get("id", "N/A"),
+                self._get_actor(record),
+                record.get("event", "N/A").replace("platform.commerce.", ""),
+                record.get("details", "N/A"),
             )
 
         return table

--- a/cli/core/console/renderers/banner.py
+++ b/cli/core/console/renderers/banner.py
@@ -1,5 +1,6 @@
 import pathlib
 import sys
+from dataclasses import dataclass
 
 from cli.core.console.base import console
 from pyfiglet import Figlet
@@ -8,58 +9,90 @@ from rich.text import Text
 HEXADECIMAL_BASE = 16
 
 
+@dataclass(frozen=True)
+class RGBColor:
+    """Represent a terminal color as red, green, and blue channels."""
+
+    red: int
+    green: int
+    blue: int
+
+    @classmethod
+    def from_hex(cls, color_hex: str) -> "RGBColor":
+        """Parse a hex color string."""
+        return cls(
+            int(color_hex[1:3], HEXADECIMAL_BASE),
+            int(color_hex[3:5], HEXADECIMAL_BASE),
+            int(color_hex[5:7], HEXADECIMAL_BASE),
+        )
+
+    def interpolate(self, target: "RGBColor", ratio: float) -> "RGBColor":
+        """Return the color at the requested position between two colors."""
+        return RGBColor(
+            self._interpolate_channel(self.red, target.red, ratio),
+            self._interpolate_channel(self.green, target.green, ratio),
+            self._interpolate_channel(self.blue, target.blue, ratio),
+        )
+
+    def as_hex(self) -> str:
+        """Format the color as a Rich-compatible hex string."""
+        red_hex = format(self.red, "02X")
+        green_hex = format(self.green, "02X")
+        blue_hex = format(self.blue, "02X")
+        color_hex = f"{red_hex}{green_hex}{blue_hex}"
+        return f"#{color_hex}"
+
+    def _interpolate_channel(self, start: int, end: int, ratio: float) -> int:
+        return int(start + ratio * (end - start))
+
+
 class BannerRenderer:
     """Render the CLI banner."""
 
     def render(self, program_name: str) -> list[Text]:
         """Build the banner lines for the current program name."""
-        prefix = program_name[:3].upper()
-        suffix = program_name[3:7]
-        normalized_program_name = f"{prefix}{suffix}"
-        figlet = Figlet("georgia11")
-        banner_text = figlet.renderText(normalized_program_name)
-
-        banner_lines = [Text(line) for line in banner_text.splitlines()]
+        banner_lines = self._render_banner_text(program_name)
         if not banner_lines:
             return []
-        max_line_length = max(len(line) for line in banner_lines)
-        half_length = max_line_length // 2
 
-        colors = self._gradient("#00C9CD", "#472AFF", half_length) + self._gradient(
+        colors = self._banner_colors(max(len(line) for line in banner_lines))
+        return [self._colorize_line(line, colors) for line in banner_lines]
+
+    def _render_banner_text(self, program_name: str) -> list[Text]:
+        prefix = program_name[:3].upper()
+        suffix = program_name[3:7]
+        normalized_program_name = prefix + suffix
+        return [
+            Text(line)
+            for line in Figlet("georgia11").renderText(normalized_program_name).splitlines()
+        ]
+
+    def _banner_colors(self, line_length: int) -> list[str]:
+        half_length = line_length // 2
+        return self._gradient("#00C9CD", "#472AFF", half_length) + self._gradient(
             "#472AFF", "#392D9C", half_length + 1
         )
 
-        rendered_lines: list[Text] = []
-        for line in banner_lines:
-            colored_line = Text()
-            for index, char in enumerate(line.plain):
-                colored_line = Text.assemble(colored_line, Text(char, style=colors[index]))
-            rendered_lines.append(colored_line)
+    def _colorize_line(self, line: Text, colors: list[str]) -> Text:
+        colored_line = Text()
+        for index, char in enumerate(line.plain):
+            colored_line = Text.assemble(colored_line, Text(char, style=colors[index]))
 
-        return rendered_lines
+        return colored_line
 
     def _gradient(
         self, start_hex: str, end_hex: str, num_samples: int = 16
     ) -> list[str]:  # pragma: no cover
-        rgb_indices = range(1, 6, 2)
-        start_hex_segments = (start_hex[index : index + 2] for index in rgb_indices)
-        end_hex_segments = (end_hex[index : index + 2] for index in rgb_indices)
-        start_rgb = tuple(int(segment, HEXADECIMAL_BASE) for segment in start_hex_segments)
-        end_rgb = tuple(int(segment, HEXADECIMAL_BASE) for segment in end_hex_segments)
-        gradient_colors = [start_hex]
-        last_sample_index = num_samples - 1
-        red_delta = end_rgb[0] - start_rgb[0]
-        green_delta = end_rgb[1] - start_rgb[1]
-        blue_delta = end_rgb[2] - start_rgb[2]
-        for sample in range(1, num_samples):
-            ratio = float(sample) / last_sample_index
-            red = int(start_rgb[0] + ratio * red_delta)
-            green = int(start_rgb[1] + ratio * green_delta)
-            blue = int(start_rgb[2] + ratio * blue_delta)
-            rgb_color = bytes((red, green, blue)).hex().upper()
-            gradient_colors.append(f"#{rgb_color}")
+        start_color = RGBColor.from_hex(start_hex)
+        end_color = RGBColor.from_hex(end_hex)
+        if num_samples <= 1:
+            return [start_color.as_hex()]
 
-        return gradient_colors
+        last_sample_index = num_samples - 1
+        return [
+            start_color.interpolate(end_color, sample / last_sample_index).as_hex()
+            for sample in range(num_samples)
+        ]
 
 
 def show_banner() -> None:

--- a/cli/core/stats.py
+++ b/cli/core/stats.py
@@ -70,23 +70,29 @@ class ErrorMessagesCollector:
         return self._is_empty
 
     def __str__(self) -> str:
-        lines: list[str] = []
-        for section_name, section in self._sections.items():
-            section_messages = section.get("", [])
-            if section_messages:
-                joined_section_messages = ", ".join(section_messages)
-                lines.append(f"{section_name}: {joined_section_messages}")
-            else:
-                lines.append(f"{section_name}:")
+        return "\n".join(self._iter_error_lines())
 
+    def _iter_error_lines(self) -> list[str]:
+        lines = []
+        for section_name, section in self._sections.items():
+            lines.append(self._format_section_line(section_name, section.get("", [])))
             for item_name, item_messages in section.items():
                 if not item_name:
                     continue
+                lines.append(self._format_item_line(item_name, item_messages))
 
-                joined_item_messages = ", ".join(item_messages)
-                lines.append(f"\t\t{item_name}: {joined_item_messages}")
+        return lines
 
-        return "\n".join(lines)
+    def _format_section_line(self, section_name: str, messages: list[str]) -> str:
+        if not messages:
+            return f"{section_name}:"
+
+        joined_messages = ", ".join(messages)
+        return f"{section_name}: {joined_messages}"
+
+    def _format_item_line(self, item_name: str, messages: list[str]) -> str:
+        joined_messages = ", ".join(messages)
+        return f"\t\t{item_name}: {joined_messages}"
 
 
 class StatsCollector(StatsStateMixin, StatsMutationMixin, ABC):

--- a/cli/plugins/audit_plugin/api.py
+++ b/cli/plugins/audit_plugin/api.py
@@ -4,15 +4,16 @@ import typer
 from cli.core.console import console
 from mpt_api_client import MPTClient, RQLQuery
 
+AUDIT_SELECT_FIELDS = ("object", "actor", "details", "documents", "request.api.geolocation")
+
 
 def get_audit_trail(client: MPTClient, record_id: str) -> dict[str, Any]:
     """Retrieve audit trail for a specific record."""
     # TODO: Using select instead of get because render() query string isn't working with get().
-    select_fields = ["object", "actor", "details", "documents", "request.api.geolocation"]
     audit_collection = client.audit.records.options(render=True)  # type: ignore[attr-defined]
     audit_collection_filtered = audit_collection.filter(RQLQuery(id=record_id))
     try:
-        records = audit_collection_filtered.select(*select_fields).fetch_page(limit=1)
+        records = audit_collection_filtered.select(*AUDIT_SELECT_FIELDS).fetch_page(limit=1)
     except Exception as error:
         console.print(
             f"[red]Failed to retrieve audit trail for record {record_id}: {error!s}[/red]"
@@ -30,12 +31,13 @@ def get_audit_records_by_object(
     client: Any, object_id: str, limit: int = 10
 ) -> list[dict[str, Any]]:
     """Retrieve all audit records for a specific object."""
-    select_fields = ["object", "actor", "details", "documents", "request.api.geolocation"]
-    object_id_filter = RQLQuery(object__id=object_id)
-    order_by = "-timestamp"
-    audit_records_collection = client.audit.records.options(render=True)
-    audit_records_filtered = audit_records_collection.filter(object_id_filter)
-    query = audit_records_filtered.order_by(order_by).select(*select_fields)
+    query = (
+        client.audit.records
+        .options(render=True)
+        .filter(RQLQuery(object__id=object_id))
+        .order_by("-timestamp")
+        .select(*AUDIT_SELECT_FIELDS)
+    )
     try:
         raw_records = query.fetch_page(limit=limit)
     except Exception as error:

--- a/cli/plugins/audit_plugin/app.py
+++ b/cli/plugins/audit_plugin/app.py
@@ -13,53 +13,91 @@ from cli.plugins.audit_plugin.audit_records import (
 )
 
 app = typer.Typer(name="audit", help="Audit commands.")
-audit_diff_renderer = AuditDiffRenderer()
 
 
-def compare_audit_trails(source_trail: dict[str, Any], target_trail: dict[str, Any]) -> None:
-    """Compare two audit trails and display the differences. Prints the differences to the console.
+class AuditTrailComparator:
+    """Compare and render audit trail differences."""
 
-    Args:
-        source_trail: The source audit trail as a dictionary.
-        target_trail: The target audit trail as a dictionary.
+    def __init__(self) -> None:
+        self._renderer = AuditDiffRenderer()
 
-    """
-    source_object_id = source_trail.get("object", {}).get("id")
-    target_object_id = target_trail.get("object", {}).get("id")
+    def compare(self, source_trail: dict[str, Any], target_trail: dict[str, Any]) -> None:
+        """Compare two audit trails and display the differences."""
+        self._check_same_object(source_trail, target_trail)
 
-    if source_object_id != target_object_id:
+        console.print(
+            self._renderer.render_summary(
+                self._object_id(source_trail),
+                source_trail.get("timestamp"),
+                target_trail.get("timestamp"),
+            )
+        )
+
+        differences = self._get_differences(source_trail, target_trail)
+        if differences:
+            console.print(self._renderer.render_differences(differences))
+        else:
+            console.print("\n[green]No differences found between the audit trails[/green]")
+
+    def select_trails(
+        self, records: list[dict[str, Any]], positions: str | None
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Select the two audit trails to compare from the loaded records."""
+        if positions:
+            try:
+                parsed_positions = _parse_positions(positions, len(records))
+            except ValueError:
+                console.print(
+                    "[red]Invalid positions. Please specify two numbers "
+                    f"between 1 and {len(records)}[/red]"
+                )
+                raise typer.Exit(1)
+
+            source_position, target_position = parsed_positions
+            return records[source_position - 1], records[target_position - 1]
+
+        console.print(
+            "[yellow]No positions specified, comparing two most recent records (1,2)[/yellow]"
+        )
+        return records[0], records[1]
+
+    def _check_same_object(
+        self, source_trail: dict[str, Any], target_trail: dict[str, Any]
+    ) -> None:
+        if self._object_id(source_trail) == self._object_id(target_trail):
+            return
+
         console.print("[red]Cannot compare different objects[/red]")
         raise typer.Exit(1)
 
-    console.print(
-        audit_diff_renderer.render_summary(
-            source_object_id,
-            source_trail.get("timestamp"),
-            target_trail.get("timestamp"),
-        )
-    )
+    def _get_differences(
+        self, source_trail: dict[str, Any], target_trail: dict[str, Any]
+    ) -> list[tuple[str, str, str]]:
+        source_flat = flatten_dict(source_trail)
+        target_flat = flatten_dict(target_trail)
+        return [
+            (
+                format_json_path(key, source_trail, target_trail),
+                self._format_value(source_flat.get(key)),
+                self._format_value(target_flat.get(key)),
+            )
+            for key in sorted(set(source_flat.keys()) | set(target_flat.keys()))
+            if source_flat.get(key) != target_flat.get(key)
+        ]
 
-    source_flat = flatten_dict(source_trail)
-    target_flat = flatten_dict(target_trail)
-    all_keys = set(source_flat.keys()) | set(target_flat.keys())
+    def _format_value(self, audit_value: Any) -> str:
+        if audit_value is None:
+            return "[red]<missing>[/red]"
 
-    differences: list[tuple[str, str, str]] = []
+        return str(audit_value)
 
-    for key in sorted(all_keys):
-        source_value = source_flat.get(key)
-        target_value = target_flat.get(key)
-        if source_value != target_value:
-            formatted_path = format_json_path(key, source_trail, target_trail)
-            differences.append((
-                formatted_path,
-                "[red]<missing>[/red]" if source_value is None else str(source_value),
-                "[red]<missing>[/red]" if target_value is None else str(target_value),
-            ))
+    def _object_id(self, audit_trail: dict[str, Any]) -> Any:
+        return audit_trail.get("object", {}).get("id")
 
-    if differences:
-        console.print(audit_diff_renderer.render_differences(differences))
-    else:
-        console.print("\n[green]No differences found between the audit trails[/green]")
+
+def compare_audit_trails(source_trail: dict[str, Any], target_trail: dict[str, Any]) -> None:
+    """Compare two audit trails and display the differences."""
+    AuditTrailComparator().compare(source_trail, target_trail)
 
 
 def _parse_positions(positions: str, records_count: int) -> tuple[int, int]:
@@ -102,26 +140,7 @@ def diff_by_object_id(
 
     display_audit_records(records)
 
-    if positions:
-        try:
-            pos1, pos2 = _parse_positions(positions, len(records))
-        except ValueError:
-            msg = (
-                "[red]Invalid positions. Please specify two numbers "
-                f"between 1 and {len(records)}[/red]"
-            )
-            console.print(msg)
-            raise typer.Exit(1)
-
-        source_trail = records[pos1 - 1]
-        target_trail = records[pos2 - 1]
-    else:
-        source_trail = records[0]
-        target_trail = records[1]
-        console.print(
-            "[yellow]No positions specified, comparing two most recent records (1,2)[/yellow]"
-        )
-
+    source_trail, target_trail = AuditTrailComparator().select_trails(records, positions)
     compare_audit_trails(source_trail, target_trail)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,11 +121,6 @@ select = ["AAA", "E999", "WPS"]
 show-source = true
 statistics = false
 per-file-ignores = [
-  "cli/core/console/renderers/audit.py:WPS210",
-  "cli/core/console/renderers/banner.py:WPS210",
-  "cli/core/stats.py:WPS210",
-  "cli/plugins/audit_plugin/api.py:WPS210",
-  "cli/plugins/audit_plugin/app.py:WPS210",
   "tests/**:WPS202,WPS204,WPS210,WPS213,WPS218,WPS221,WPS432"
 ]
 


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## Summary

- Refactor the remaining production WPS210 hotspots without keeping production per-file ignores.
- Introduce `RGBColor` for banner gradient color handling.
- Keep the test-only wemake ignore entry unchanged.

## Testing
- `docker compose run --rm app flake8 cli --per-file-ignores=""`
- `make check-all`
- Commit hooks: ruff, formatting, flake8, mypy, uv-lock


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-17825](https://softwareone.atlassian.net/browse/MPT-17825)

## Release Notes

- **Refactored audit record rendering** – `AuditRecordsRenderer.render()` now builds table rows inline, eliminating intermediate local variables while maintaining the same output behavior.

- **Introduced RGBColor utility for banner colors** – New `RGBColor` dataclass encapsulates hex parsing, channel interpolation, and Rich-compatible hex formatting; `BannerRenderer` now uses helper methods (`_render_banner_text`, `_banner_colors`, `_colorize_line`) for cleaner gradient color handling.

- **Refactored error message formatting** – `ErrorMessagesCollector.__str__()` now delegates to `_iter_error_lines()` helper with dedicated formatting methods (`_format_section_line`, `_format_item_line`) for improved maintainability.

- **Standardized audit field selection** – Introduced `AUDIT_SELECT_FIELDS` module constant; audit API functions now use this constant instead of local field lists, improving consistency.

- **Introduced AuditTrailComparator class** – New class encapsulates audit trail comparison logic, diff rendering, and trail selection; `compare_audit_trails()` function now delegates to this class for better separation of concerns.

- **Removed production WPS210 ignores from flake8 config** – Cleaned up `pyproject.toml` to remove per-file WPS210 ignores for production modules, keeping only test-related entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softwareone-platform/swo-marketplace-cli/pull/215)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-17825]: https://softwareone.atlassian.net/browse/MPT-17825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ