### PR TITLE
MPT-17825: Remove WPS204 test ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ select = ["AAA", "E999", "WPS"]
 show-source = true
 statistics = false
 per-file-ignores = [
-  "tests/**:WPS202,WPS204,WPS210,WPS213,WPS218,WPS221,WPS432"
+  "tests/**:WPS202,WPS210,WPS213,WPS218,WPS221,WPS432"
 ]
 
 [tool.ruff]

--- a/tests/cli/core/accounts/conftest.py
+++ b/tests/cli/core/accounts/conftest.py
@@ -22,6 +22,16 @@ def new_accounts_path(tmp_path, accounts_path):
 
 
 @pytest.fixture
+def account_file_path(tmp_path):
+    return tmp_path / ".swocli" / "accounts.json"
+
+
+@pytest.fixture
+def stored_accounts(active_vendor_account, inactive_vendor_account):
+    return [active_vendor_account, inactive_vendor_account]
+
+
+@pytest.fixture
 def inactive_vendor_account():
     return CLIAccount(
         id="ACC-12342",

--- a/tests/cli/core/accounts/test_app.py
+++ b/tests/cli/core/accounts/test_app.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 
 import pytest
 import typer
@@ -37,9 +36,28 @@ def existing_token_factory():
     return factory
 
 
-def test_add_account_accounts_file_not_exists(tmp_path, mocker, vendor_token):
-    account_file_path = tmp_path / ".swocli" / "accounts.json"
+@pytest.fixture
+def account_file_path_patch(mocker, account_file_path):
     mocker.patch.object(JsonFileHandler, "_default_file_path", account_file_path)
+
+
+@pytest.fixture
+def new_accounts_path_patch(mocker, new_accounts_path):
+    mocker.patch.object(JsonFileHandler, "_default_file_path", new_accounts_path)
+
+
+def load_stored_accounts(file_path):
+    with file_path.open(encoding="utf-8") as opened_file:
+        return json.load(opened_file)
+
+
+def assert_account_command_success(result):
+    assert result.exit_code == 0, result.stdout
+
+
+def test_add_account_accounts_file_not_exists(
+    account_file_path, account_file_path_patch, mocker, vendor_token
+):
     mocker.patch(
         "cli.core.accounts.api.account_api_service.MPTAccountService.get_authentication",
         return_value=vendor_token,
@@ -49,8 +67,7 @@ def test_add_account_accounts_file_not_exists(tmp_path, mocker, vendor_token):
     result = runner.invoke(app, ["add", "idt:TKN-1111-1111:secret"])
 
     assert result.exit_code == 0, result.stdout
-    with Path(account_file_path).open(encoding="utf-8") as opened_file:
-        loaded_accounts = json.load(opened_file)
+    loaded_accounts = load_stored_accounts(account_file_path)
     assert loaded_accounts == [
         {
             "id": "ACC-12345new",
@@ -64,8 +81,9 @@ def test_add_account_accounts_file_not_exists(tmp_path, mocker, vendor_token):
     ]
 
 
-def test_add_account_accounts_file_exists(new_accounts_path, mocker, vendor_token):
-    mocker.patch.object(JsonFileHandler, "_default_file_path", new_accounts_path)
+def test_add_account_accounts_file_exists(
+    new_accounts_path, new_accounts_path_patch, mocker, vendor_token
+):
     mocker.patch(
         "cli.core.accounts.api.account_api_service.MPTAccountService.get_authentication",
         return_value=vendor_token,
@@ -75,8 +93,7 @@ def test_add_account_accounts_file_exists(new_accounts_path, mocker, vendor_toke
     result = runner.invoke(app, ["add", "idt:TKN-1111-1111:secret"])
 
     assert result.exit_code == 0, result.stdout
-    with Path(new_accounts_path).open(encoding="utf-8") as opened_file:
-        loaded_accounts = json.load(opened_file)
+    loaded_accounts = load_stored_accounts(new_accounts_path)
     assert loaded_accounts == [
         {
             "id": "ACC-12341",
@@ -108,8 +125,9 @@ def test_add_account_accounts_file_exists(new_accounts_path, mocker, vendor_toke
     ]
 
 
-def test_add_account_override_environment(new_accounts_path, mocker, vendor_token):
-    mocker.patch.object(JsonFileHandler, "_default_file_path", new_accounts_path)
+def test_add_account_override_environment(
+    new_accounts_path, new_accounts_path_patch, mocker, vendor_token
+):
     mocker.patch(
         "cli.core.accounts.api.account_api_service.MPTAccountService.get_authentication",
         return_value=vendor_token,
@@ -127,8 +145,7 @@ def test_add_account_override_environment(new_accounts_path, mocker, vendor_toke
     )
 
     assert result.exit_code == 0, result.stdout
-    with Path(new_accounts_path).open(encoding="utf-8") as opened_file:
-        loaded_accounts = json.load(opened_file)
+    loaded_accounts = load_stored_accounts(new_accounts_path)
     assert loaded_accounts == [
         {
             "id": "ACC-12341",
@@ -160,8 +177,7 @@ def test_add_account_override_environment(new_accounts_path, mocker, vendor_toke
     ]
 
 
-def test_add_account_token_failed(new_accounts_path, mocker):
-    mocker.patch.object(JsonFileHandler, "_default_file_path", new_accounts_path)
+def test_add_account_token_failed(new_accounts_path_patch, mocker):
     mocker.patch(
         "cli.core.accounts.api.account_api_service.MPTAccountService.get_authentication",
         side_effect=MPTAPIError("critical error", "you can't perform the operation"),
@@ -173,8 +189,9 @@ def test_add_account_token_failed(new_accounts_path, mocker):
     assert result.exit_code == 3, result.stdout
 
 
-def test_add_existing_account_do_not_replace(new_accounts_path, mocker, existing_token_factory):
-    mocker.patch.object(JsonFileHandler, "_default_file_path", new_accounts_path)
+def test_add_existing_account_do_not_replace(
+    new_accounts_path, new_accounts_path_patch, mocker, existing_token_factory
+):
     mocker.patch(
         "cli.core.accounts.api.account_api_service.MPTAccountService.get_authentication",
         return_value=existing_token_factory("idt:TKN-1111-1111:secret"),
@@ -184,8 +201,7 @@ def test_add_existing_account_do_not_replace(new_accounts_path, mocker, existing
     result = runner.invoke(app, ["add", "idt:TKN-1111-1111:secret"], input="N\n")
 
     assert result.exit_code == 1, result.stdout
-    with Path(new_accounts_path).open(encoding="utf-8") as opened_file:
-        loaded_accounts = json.load(opened_file)
+    loaded_accounts = load_stored_accounts(new_accounts_path)
     assert loaded_accounts == [
         {
             "id": "ACC-12341",
@@ -208,8 +224,9 @@ def test_add_existing_account_do_not_replace(new_accounts_path, mocker, existing
     ]
 
 
-def test_add_existing_account_replace(new_accounts_path, mocker, existing_token_factory):
-    mocker.patch.object(JsonFileHandler, "_default_file_path", new_accounts_path)
+def test_add_existing_account_replace(
+    new_accounts_path, new_accounts_path_patch, mocker, existing_token_factory
+):
     mocker.patch(
         "cli.core.accounts.api.account_api_service.MPTAccountService.get_authentication",
         return_value=existing_token_factory("idt:TKN-1111-1111:secret"),
@@ -218,9 +235,8 @@ def test_add_existing_account_replace(new_accounts_path, mocker, existing_token_
 
     result = runner.invoke(app, ["add", "idt:TKN-1111-1111:secret"], input="y\n")
 
-    assert result.exit_code == 0, result.stdout
-    with Path(new_accounts_path).open(encoding="utf-8") as opened_file:
-        loaded_accounts = json.load(opened_file)
+    assert_account_command_success(result)
+    loaded_accounts = load_stored_accounts(new_accounts_path)
     assert loaded_accounts == [
         {
             "id": "ACC-12341",
@@ -243,31 +259,23 @@ def test_add_existing_account_replace(new_accounts_path, mocker, existing_token_
     ]
 
 
-def test_activate_account_file_not_exists(tmp_path, mocker):
-    account_file_path = tmp_path / ".swocli" / "accounts.json"
-    mocker.patch.object(JsonFileHandler, "_default_file_path", account_file_path)
-
+def test_activate_account_file_not_exists(account_file_path_patch):
     result = runner.invoke(app, ["activate", "ACC-12345"])
 
     assert result.exit_code == 3, result.stdout
 
 
-def test_activate_account_doesnot_exist(new_accounts_path, mocker):
-    mocker.patch.object(JsonFileHandler, "_default_file_path", new_accounts_path)
-
+def test_activate_account_doesnot_exist(new_accounts_path_patch):
     result = runner.invoke(app, ["activate", "ACC-not-exists"])
 
     assert result.exit_code == 3, result.stdout
 
 
-def test_activate_account(new_accounts_path, mocker):
-    mocker.patch.object(JsonFileHandler, "_default_file_path", new_accounts_path)
-
+def test_activate_account(new_accounts_path, new_accounts_path_patch):
     result = runner.invoke(app, ["activate", "ACC-12342"])
 
-    assert result.exit_code == 0, result.stdout
-    with Path(new_accounts_path).open(encoding="utf-8") as opened_file:
-        loaded_accounts = json.load(opened_file)
+    assert_account_command_success(result)
+    loaded_accounts = load_stored_accounts(new_accounts_path)
     assert loaded_accounts == [
         {
             "id": "ACC-12341",
@@ -290,39 +298,29 @@ def test_activate_account(new_accounts_path, mocker):
     ]
 
 
-def test_remove_accounts_file_not_exists(tmp_path, mocker):
-    account_file_path = tmp_path / ".swocli" / "accounts.json"
-    mocker.patch.object(JsonFileHandler, "_default_file_path", account_file_path)
-
+def test_remove_accounts_file_not_exists(account_file_path_patch):
     result = runner.invoke(app, ["remove", "ACC-12345"])
 
     assert result.exit_code == 3, result.stdout
 
 
-def test_remove_account_doesnot_exist(new_accounts_path, mocker):
-    mocker.patch.object(JsonFileHandler, "_default_file_path", new_accounts_path)
-
+def test_remove_account_doesnot_exist(new_accounts_path_patch):
     result = runner.invoke(app, ["remove", "ACC-not-exists"])
 
     assert result.exit_code == 3, result.stdout
 
 
-def test_remove_account_donot_remove(new_accounts_path, mocker):
-    mocker.patch.object(JsonFileHandler, "_default_file_path", new_accounts_path)
-
+def test_remove_account_donot_remove(new_accounts_path_patch):
     result = runner.invoke(app, ["remove", "ACC-12341"], input="N\n")
 
     assert result.exit_code == 1, result.stdout
 
 
-def test_remove_account(new_accounts_path, mocker):
-    mocker.patch.object(JsonFileHandler, "_default_file_path", new_accounts_path)
-
+def test_remove_account(new_accounts_path, new_accounts_path_patch):
     result = runner.invoke(app, ["remove", "ACC-12341"], input="y\n")
 
-    assert result.exit_code == 0, result.stdout
-    with Path(new_accounts_path).open(encoding="utf-8") as opened_file:
-        loaded_accounts = json.load(opened_file)
+    assert_account_command_success(result)
+    loaded_accounts = load_stored_accounts(new_accounts_path)
     assert loaded_accounts == [
         {
             "id": "ACC-12342",
@@ -336,48 +334,37 @@ def test_remove_account(new_accounts_path, mocker):
     ]
 
 
-def test_list_accounts_accounts_file_not_exists(tmp_path, mocker):
-    account_file_path = tmp_path / ".swocli" / "accounts.json"
-    mocker.patch.object(JsonFileHandler, "_default_file_path", account_file_path)
-
+def test_list_accounts_accounts_file_not_exists(account_file_path_patch):
     result = runner.invoke(app, ["list"])
 
-    assert result.exit_code == 0, result.stdout
+    assert_account_command_success(result)
 
 
-def test_list_accounts(new_accounts_path, mocker):
-    mocker.patch.object(JsonFileHandler, "_default_file_path", new_accounts_path)
-
+def test_list_accounts(new_accounts_path_patch):
     result = runner.invoke(app, ["list"])
 
-    assert result.exit_code == 0, result.stdout
+    assert_account_command_success(result)
     assert all((account in result.stdout) for account in ("ACC-12341", "ACC-12342")), result.stdout
 
 
-def test_list_active_account(new_accounts_path, mocker):
-    mocker.patch.object(JsonFileHandler, "_default_file_path", new_accounts_path)
-
+def test_list_active_account(new_accounts_path_patch):
     result = runner.invoke(app, ["list", "--active"])
 
-    assert result.exit_code == 0, result.stdout
+    assert_account_command_success(result)
     assert "ACC-12341" in result.stdout
     assert "ACC-12342" not in result.stdout
 
 
-def test_get_active_account(new_accounts_path, mocker, active_vendor_account):
-    mocker.patch.object(JsonFileHandler, "_default_file_path", new_accounts_path)
-
+def test_get_active_account(new_accounts_path_patch, active_vendor_account):
     result = get_active_account()
 
     assert result == active_vendor_account
 
 
-def test_get_active_account_no_active_account(new_accounts_path, mocker):
-    mocker.patch.object(JsonFileHandler, "_default_file_path", new_accounts_path)
-    with Path(new_accounts_path).open(encoding="utf-8") as opened_file:
-        loaded_accounts = json.load(opened_file)
+def test_get_active_account_no_active_account(new_accounts_path, new_accounts_path_patch):
+    loaded_accounts = load_stored_accounts(new_accounts_path)
     loaded_accounts = [{**account_record, "is_active": False} for account_record in loaded_accounts]
-    with Path(new_accounts_path).open("w", encoding="utf-8") as opened_file:
+    with new_accounts_path.open("w", encoding="utf-8") as opened_file:
         json.dump(loaded_accounts, opened_file)
 
     with pytest.raises(typer.Exit):

--- a/tests/cli/core/accounts/test_flows.py
+++ b/tests/cli/core/accounts/test_flows.py
@@ -43,28 +43,23 @@ def test_get_or_create_accounts_create(mocker, tmp_path):
     assert result == []
 
 
-def test_get_or_create_accounts_get(
-    mocker, accounts_path, active_vendor_account, inactive_vendor_account
-):
+def test_get_or_create_accounts_get(mocker, accounts_path, stored_accounts):
     mocker.patch.object(JsonFileHandler, "_default_file_path", accounts_path)
 
     result = get_or_create_accounts()
 
-    expected_accounts = [active_vendor_account, inactive_vendor_account]
-    assert result == expected_accounts
+    assert result == stored_accounts
 
 
-def test_does_account_exist(active_vendor_account, inactive_vendor_account):
-    result = does_account_exist(
-        [active_vendor_account, inactive_vendor_account], active_vendor_account
-    )
+def test_does_account_exist(stored_accounts, active_vendor_account):
+    result = does_account_exist(stored_accounts, active_vendor_account)
 
     assert result is True
 
 
-def test_doesnot_account_exist(active_vendor_account, inactive_vendor_account):
+def test_doesnot_account_exist(stored_accounts):
     result = does_account_exist(
-        [active_vendor_account, inactive_vendor_account],
+        stored_accounts,
         Account(
             id="ACC-4321",
             name="Not exists account",
@@ -79,66 +74,54 @@ def test_doesnot_account_exist(active_vendor_account, inactive_vendor_account):
     assert result is False
 
 
-def test_remove_account(active_vendor_account, inactive_vendor_account):
-    accounts = [active_vendor_account, inactive_vendor_account]
-
-    result = remove_account(accounts, inactive_vendor_account)
+def test_remove_account(stored_accounts, active_vendor_account, inactive_vendor_account):
+    result = remove_account(stored_accounts, inactive_vendor_account)
 
     assert result == [active_vendor_account]
 
 
-def test_write_accounts(mocker, tmp_path, active_vendor_account, inactive_vendor_account):
+def test_write_accounts(mocker, tmp_path, stored_accounts):
     file_path = tmp_path / ".swocli" / "accounts.json"
     mocker.patch.object(JsonFileHandler, "_default_file_path", file_path)
-    accounts = [active_vendor_account, inactive_vendor_account]
-    write_accounts(accounts)
+    write_accounts(stored_accounts)
     with Path(file_path).open(encoding="utf-8") as file_obj:
         written_accounts = json.load(file_obj)
 
     result = sorted(written_accounts, key=itemgetter("id"))
 
-    assert result == [account.model_dump() for account in accounts]
+    assert result == [account.model_dump() for account in stored_accounts]
 
 
-def test_disable_accounts_except(active_vendor_account, inactive_vendor_account):
-    accounts = [active_vendor_account, inactive_vendor_account]
-
-    disable_accounts_except(accounts, inactive_vendor_account)  # act
+def test_disable_accounts_except(stored_accounts, active_vendor_account, inactive_vendor_account):
+    disable_accounts_except(stored_accounts, inactive_vendor_account)  # act
 
     assert not active_vendor_account.is_active
     assert inactive_vendor_account.is_active
 
 
-def test_find_account(active_vendor_account, inactive_vendor_account):
-    result = find_account(
-        [active_vendor_account, inactive_vendor_account], active_vendor_account.id
-    )
+def test_find_account(stored_accounts, active_vendor_account):
+    result = find_account(stored_accounts, active_vendor_account.id)
 
     assert result == active_vendor_account
 
 
-def test_find_account_exception(active_vendor_account, inactive_vendor_account):
-    accounts = [active_vendor_account, inactive_vendor_account]
-
+def test_find_account_exception(stored_accounts):
     with pytest.raises(AccountNotFoundError) as error:
-        find_account(accounts, "another-account-id")
+        find_account(stored_accounts, "another-account-id")
 
     assert "nother-account-id" in str(error.value)
 
 
-def test_find_active_account(active_vendor_account, inactive_vendor_account):
-    accounts = [active_vendor_account, inactive_vendor_account]
-
-    result = find_active_account(accounts)
+def test_find_active_account(stored_accounts, active_vendor_account):
+    result = find_active_account(stored_accounts)
 
     assert result == active_vendor_account
 
 
-def test_find_active_account_exception(active_vendor_account, inactive_vendor_account):
+def test_find_active_account_exception(stored_accounts, active_vendor_account):
     active_vendor_account.is_active = False
-    accounts = [active_vendor_account, inactive_vendor_account]
 
     with pytest.raises(NoActiveAccountFoundError) as error:
-        find_active_account(accounts)
+        find_active_account(stored_accounts)
 
     assert "No active account found. Activate any account first" in str(error.value)

--- a/tests/cli/core/mpt/test_api.py
+++ b/tests/cli/core/mpt/test_api.py
@@ -32,6 +32,16 @@ def api_service(collection_service):
     return FakeApiService(collection_service)
 
 
+@pytest.fixture
+def mpt_resource(mocker):
+    return mocker.MagicMock(spec=Model)
+
+
+@pytest.fixture
+def mpt_api_error_type():
+    return MPTAPIError
+
+
 class FakeRelatedApiService(RelatedAPIService):
     _base_url = "fake_url/{resource_id}/action"
     _api_model = FakeModel
@@ -53,10 +63,9 @@ def related_api_service(collection_service):
         ({"select": "field1"}, "field1"),
     ],
 )
-def test_get(query_params, expected_select, api_service, collection_service, mocker):
-    resource_mock = mocker.MagicMock(spec=Model)
-    resource_mock.to_dict.return_value = {"id": "fakeId", "name": "test"}
-    collection_service.get.return_value = resource_mock
+def test_get(query_params, expected_select, api_service, collection_service, mpt_resource):
+    mpt_resource.to_dict.return_value = {"id": "fakeId", "name": "test"}
+    collection_service.get.return_value = mpt_resource
 
     result = api_service.get("fakeId", query_params=query_params)
 
@@ -75,19 +84,18 @@ def test_exists(total, expected_response, api_service, collection_service):
     collection_service.fetch_page.assert_called_once_with(limit=0)
 
 
-def test_list_with_query_params(mocker, api_service, collection_service):
+def test_list_with_query_params(mocker, api_service, collection_service, mpt_resource):
     query_params = {"bla": "foo"}
     expected_meta_data = {"offset": 0, "limit": 100, "total": 10}
     expected_data = [{"id": "fakeId", "name": "test"}]
-    resource_mock = mocker.MagicMock(spec=Model)
-    resource_mock.to_dict.return_value = expected_data[0]
+    mpt_resource.to_dict.return_value = expected_data[0]
     collection = mocker.MagicMock(spec=ModelCollection)
     collection.meta = mocker.MagicMock(spec=Meta)
     collection.meta.pagination = mocker.MagicMock(spec=Pagination)
     collection.meta.pagination.limit = 100
     collection.meta.pagination.offset = 0
     collection.meta.pagination.total = 10
-    collection.resources = [resource_mock]
+    collection.resources = [mpt_resource]
     collection_service.filter.return_value.fetch_page.return_value = collection
 
     result = api_service.list(query_params=query_params)
@@ -95,19 +103,18 @@ def test_list_with_query_params(mocker, api_service, collection_service):
     assert result == {"meta": expected_meta_data, "data": expected_data}
 
 
-def test_list_with_no_query_params(mocker, api_service, collection_service):
+def test_list_with_no_query_params(mocker, api_service, collection_service, mpt_resource):
     query_params = None
     expected_meta_data = {"offset": 0, "limit": 100, "total": 10}
     expected_data = [{"id": "fakeId", "name": "test"}]
-    resource_mock = mocker.MagicMock(spec=Model)
-    resource_mock.to_dict.return_value = expected_data[0]
+    mpt_resource.to_dict.return_value = expected_data[0]
     collection = mocker.MagicMock(spec=ModelCollection)
     collection.meta = mocker.MagicMock(spec=Meta)
     collection.meta.pagination = mocker.MagicMock(spec=Pagination)
     collection.meta.pagination.limit = 100
     collection.meta.pagination.offset = 0
     collection.meta.pagination.total = 10
-    collection.resources = [resource_mock]
+    collection.resources = [mpt_resource]
     collection_service.fetch_page.return_value = collection
 
     result = api_service.list(query_params=query_params)
@@ -130,10 +137,9 @@ def test_list_no_data(mocker, api_service, collection_service):
     assert result == {"meta": {"limit": 100, "offset": 0, "total": 0}, "data": []}
 
 
-def test_post(mocker, api_service, collection_service):
-    resource_mock = mocker.MagicMock(spec=Model)
-    resource_mock.to_dict.return_value = {"id": "fakeId", "name": "test"}
-    collection_service.create.return_value = resource_mock
+def test_post(api_service, collection_service, mpt_resource):
+    mpt_resource.to_dict.return_value = {"id": "fakeId", "name": "test"}
+    collection_service.create.return_value = mpt_resource
 
     result = api_service.post(json={"name": "test"})
 
@@ -147,17 +153,16 @@ def test_post_action(api_service, collection_service):
     collection_service.publish.assert_called_once_with("fake_resource_id")
 
 
-def test_post_action_unsupported_raises(api_service):
-    with pytest.raises(MPTAPIError) as error:
+def test_post_action_unsupported_raises(api_service, mpt_api_error_type):
+    with pytest.raises(mpt_api_error_type) as error:
         api_service.post_action("fake_resource_id", "unsupported_action")
 
     assert "Unsupported action 'unsupported_action'" in str(error.value)
 
 
-def test_update_success(mocker, api_service, collection_service):
-    resource_mock = mocker.MagicMock(spec=Model)
-    resource_mock.to_dict.return_value = {"id": "fakeId", "bla": "foo", "name": "test"}
-    collection_service.update.return_value = resource_mock
+def test_update_success(api_service, collection_service, mpt_resource):
+    mpt_resource.to_dict.return_value = {"id": "fakeId", "bla": "foo", "name": "test"}
+    collection_service.update.return_value = mpt_resource
 
     result = api_service.update("fakeId", {"bla": "foo", "name": "test"})
 
@@ -202,12 +207,12 @@ def test_get_not_found(api_service, collection_service):
         api_service.get("missing_id")
 
 
-def test_get_exception(api_service, collection_service):
+def test_get_exception(api_service, collection_service, mpt_api_error_type):
     collection_service.get.side_effect = ClientAPIError(
         500, "Server Error", {"status": 500, "message": "Server Error"}
     )
 
-    with pytest.raises(MPTAPIError):
+    with pytest.raises(mpt_api_error_type):
         api_service.get("fakeId")
 
 
@@ -227,10 +232,9 @@ def test_list_with_select(mocker, api_service, collection_service):
     collection_service.select.assert_called_once_with("field1")
 
 
-def test_post_with_form_payload(mocker, api_service, collection_service):
-    resource_mock = mocker.MagicMock(spec=Model)
-    resource_mock.to_dict.return_value = {"id": "newId", "name": "created"}
-    collection_service.create.return_value = resource_mock
+def test_post_with_form_payload(mocker, api_service, collection_service, mpt_resource):
+    mpt_resource.to_dict.return_value = {"id": "newId", "name": "created"}
+    collection_service.create.return_value = mpt_resource
     form_payload = mocker.MagicMock(spec=MultipartEncoder)
     form_payload.fields = {
         "data": '{"name": "test"}',
@@ -245,13 +249,12 @@ def test_post_with_form_payload(mocker, api_service, collection_service):
     )
 
 
-def test_update_with_sub_resource(mocker, api_service, collection_service):
-    resource_mock = mocker.MagicMock(spec=Model)
-    collection_service.update_settings.return_value = resource_mock
+def test_update_with_sub_resource(api_service, collection_service, mpt_resource):
+    collection_service.update_settings.return_value = mpt_resource
 
     result = api_service.update("fakeId/settings", {"setting": "value"})
 
-    assert result == resource_mock.to_dict()
+    assert result == mpt_resource.to_dict()
     collection_service.update_settings.assert_called_once_with("fakeId", {"setting": "value"})
 
 
@@ -263,11 +266,11 @@ def test_exists_raises_when_meta_is_none(api_service, collection_service):
         api_service.exists()
 
 
-def test_exists_raises_when_pagination_is_none(api_service, collection_service):
+def test_exists_raises_when_pagination_is_none(api_service, collection_service, mpt_api_error_type):
     collection_page = collection_service.fetch_page.return_value
     collection_page.meta.pagination = None
 
-    with pytest.raises(MPTAPIError):
+    with pytest.raises(mpt_api_error_type):
         api_service.exists()
 
 
@@ -279,18 +282,17 @@ def test_list_raises_when_meta_is_none(api_service, collection_service):
         api_service.list()
 
 
-def test_list_raises_when_pagination_is_none(api_service, collection_service):
+def test_list_raises_when_pagination_is_none(api_service, collection_service, mpt_api_error_type):
     collection_page = collection_service.fetch_page.return_value
     collection_page.meta.pagination = None
 
-    with pytest.raises(MPTAPIError):
+    with pytest.raises(mpt_api_error_type):
         api_service.list()
 
 
-def test_post_form_payload_unknown_field(mocker, api_service, collection_service):
-    resource_mock = mocker.MagicMock(spec=Model)
-    resource_mock.to_dict.return_value = {"id": "newId", "name": "created"}
-    collection_service.create.return_value = resource_mock
+def test_post_form_payload_unknown_field(mocker, api_service, collection_service, mpt_resource):
+    mpt_resource.to_dict.return_value = {"id": "newId", "name": "created"}
+    collection_service.create.return_value = mpt_resource
     form_payload = mocker.MagicMock(spec=MultipartEncoder)
     form_payload.fields = {
         "data": '{"name": "test"}',

--- a/tests/cli/core/price_lists/services/test_item_service.py
+++ b/tests/cli/core/price_lists/services/test_item_service.py
@@ -24,13 +24,18 @@ def service_context(
     )
 
 
-def test_export(mocker, service_context, mpt_item_data):
+@pytest.fixture
+def item_service(service_context):
+    return ItemService(service_context)
+
+
+def test_export(mocker, service_context, item_service, mpt_item_data):
     create_tab_mock = mocker.patch.object(service_context.file_manager, "create_tab")
     add_mock = mocker.patch.object(service_context.file_manager, "add")
     response_data = {"data": [mpt_item_data], "meta": {"offset": 1, "limit": 100, "total": 1}}
     api_list_mock = mocker.patch.object(service_context.api, "list", side_effect=[response_data])
 
-    result = ItemService(service_context).export()
+    result = item_service.export()
 
     assert result.success is True
     create_tab_mock.assert_called_once()
@@ -38,7 +43,7 @@ def test_export(mocker, service_context, mpt_item_data):
     api_list_mock.assert_called()
 
 
-def test_export_paginates_until_total(mocker, service_context, mpt_item_data):
+def test_export_paginates_until_total(mocker, service_context, item_service, mpt_item_data):
     create_tab_mock = mocker.patch.object(service_context.file_manager, "create_tab")
     add_mock = mocker.patch.object(service_context.file_manager, "add")
     first_page = {"data": [mpt_item_data], "meta": {"offset": 0, "limit": 1, "total": 2}}
@@ -47,7 +52,7 @@ def test_export_paginates_until_total(mocker, service_context, mpt_item_data):
         service_context.api, "list", side_effect=[first_page, second_page]
     )
 
-    result = ItemService(service_context).export()
+    result = item_service.export()
 
     assert result.success is True
     create_tab_mock.assert_called_once()
@@ -58,14 +63,14 @@ def test_export_paginates_until_total(mocker, service_context, mpt_item_data):
     assert second_call.args[0]["offset"] > first_call.args[0]["offset"]
 
 
-def test_export_mpt_error(mocker, service_context):
+def test_export_mpt_error(mocker, service_context, item_service):
     create_tab_mock = mocker.patch.object(service_context.file_manager, "create_tab")
     api_list_mock = mocker.patch.object(
         service_context.api, "list", side_effect=MPTAPIError("API Error", "Error retrieving item")
     )
     add_spy = mocker.spy(service_context.file_manager, "add")
 
-    result = ItemService(service_context).export()
+    result = item_service.export()
 
     assert result.success is False
     create_tab_mock.assert_called_once()
@@ -73,30 +78,30 @@ def test_export_mpt_error(mocker, service_context):
     add_spy.assert_not_called()
 
 
-def test_retrieve_from_mpt(mocker, service_context, mpt_item_data, item_data_from_json):
+def test_retrieve_from_mpt(
+    mocker, service_context, item_service, mpt_item_data, item_data_from_json
+):
     api_get_mock = mocker.patch.object(
         service_context.api,
         "get",
         return_value=mocker.Mock(spec=Response, json=mocker.Mock(return_value=mpt_item_data)),
     )
-    service = ItemService(service_context)
 
-    result = service.retrieve_from_mpt(item_data_from_json.id)
+    result = item_service.retrieve_from_mpt(item_data_from_json.id)
 
     assert result.success is True
     assert result.model == item_data_from_json
     api_get_mock.assert_called_once_with(item_data_from_json.id)
 
 
-def test_retrieve_from_mpt_error(mocker, service_context):
+def test_retrieve_from_mpt_error(mocker, service_context, item_service):
     api_get_mock = mocker.patch.object(
         service_context.api,
         "get",
         side_effect=MPTAPIError("API Error", "Error retrieving item"),
     )
-    service = ItemService(service_context)
 
-    result = service.retrieve_from_mpt("fake_id")
+    result = item_service.retrieve_from_mpt("fake_id")
 
     assert result.success is False
     assert len(result.errors) > 0
@@ -104,7 +109,7 @@ def test_retrieve_from_mpt_error(mocker, service_context):
     api_get_mock.assert_called_once_with("fake_id")
 
 
-def test_update_item(mocker, service_context, mpt_item_data, item_data_from_dict):
+def test_update_item(mocker, service_context, item_service, mpt_item_data, item_data_from_dict):
     mocker.patch.object(item_data_from_dict, "to_update", return_value=True)
     mocker.patch.object(
         service_context.file_manager, "read_data", return_value=[item_data_from_dict]
@@ -113,9 +118,8 @@ def test_update_item(mocker, service_context, mpt_item_data, item_data_from_dict
     write_ids_mock = mocker.patch.object(service_context.file_manager, "write_ids")
     update_mock = mocker.patch.object(service_context.api, "update", return_value=mpt_item_data)
     stats_spy = mocker.spy(service_context.stats, "add_synced")
-    service = ItemService(service_context)
 
-    result = service.update()
+    result = item_service.update()
 
     assert result.success is True
     assert result.model is None
@@ -125,7 +129,7 @@ def test_update_item(mocker, service_context, mpt_item_data, item_data_from_dict
     stats_spy.assert_called_once_with(TAB_PRICE_ITEMS)
 
 
-def test_update_item_api_list_error(mocker, service_context):
+def test_update_item_api_list_error(mocker, service_context, item_service):
     mocker.patch.object(
         service_context.api,
         "list",
@@ -134,9 +138,8 @@ def test_update_item_api_list_error(mocker, service_context):
     file_handler_mock = mocker.patch.object(service_context.file_manager, "write_error")
     api_update_spy = mocker.spy(service_context.api, "update")
     stats_add_synced_spy = mocker.spy(service_context.stats, "add_synced")
-    service = ItemService(service_context)
 
-    result = service.update()
+    result = item_service.update()
 
     assert result.success is False
     assert len(result.errors) > 0
@@ -146,14 +149,13 @@ def test_update_item_api_list_error(mocker, service_context):
     stats_add_synced_spy.assert_not_called()
 
 
-def test_update_item_empty_list_response(mocker, service_context):
+def test_update_item_empty_list_response(mocker, service_context, item_service):
     mocker.patch.object(service_context.api, "list", return_value={"data": []})
     file_handler_mock = mocker.patch.object(service_context.file_manager, "write_error")
     api_update_spy = mocker.spy(service_context.api, "update")
     stats_add_synced_spy = mocker.spy(service_context.stats, "add_synced")
-    service = ItemService(service_context)
 
-    result = service.update()
+    result = item_service.update()
 
     assert result.success is False
     assert len(result.errors) > 0
@@ -163,7 +165,9 @@ def test_update_item_empty_list_response(mocker, service_context):
     stats_add_synced_spy.assert_not_called()
 
 
-def test_update_item_api_update_error(mocker, service_context, mpt_item_data, item_data_from_dict):
+def test_update_item_api_update_error(
+    mocker, service_context, item_service, mpt_item_data, item_data_from_dict
+):
     mocker.patch.object(item_data_from_dict, "to_update", return_value=True)
     mocker.patch.object(
         service_context.file_manager, "read_data", return_value=[item_data_from_dict]
@@ -176,22 +180,21 @@ def test_update_item_api_update_error(mocker, service_context, mpt_item_data, it
     )
     file_handler_mock = mocker.patch.object(service_context.file_manager, "write_error")
 
-    result = ItemService(service_context).update()
+    result = item_service.update()
 
     assert result.success is False
     assert any("Item" in item_error for item_error in result.errors)
     file_handler_mock.assert_called()
 
 
-def test_update_item_not_found(mocker, service_context):
+def test_update_item_not_found(mocker, service_context, item_service):
     mocker.patch.object(
         service_context.api, "list", side_effect=MPTAPIError("API Error", "Item not found")
     )
     file_handler_mock = mocker.patch.object(service_context.file_manager, "write_error")
     stats_spy = mocker.spy(service_context.stats, "add_error")
-    service = ItemService(service_context)
 
-    result = service.update()
+    result = item_service.update()
 
     assert not result.success
     assert len(result.errors) > 0
@@ -200,7 +203,9 @@ def test_update_item_not_found(mocker, service_context):
     stats_spy.assert_called()
 
 
-def test_update_item_skip(mocker, service_context, mpt_item_data, item_data_from_json):
+def test_update_item_skip(
+    mocker, service_context, item_service, mpt_item_data, item_data_from_json
+):
     mocker.patch.object(
         service_context.file_manager, "read_data", return_value=[item_data_from_json]
     )
@@ -208,9 +213,8 @@ def test_update_item_skip(mocker, service_context, mpt_item_data, item_data_from
     write_ids_mock = mocker.spy(service_context.file_manager, "write_ids")
     api_update_spy = mocker.spy(service_context.api, "update")
     stats_spy = mocker.spy(service_context.stats, "add_skipped")
-    service = ItemService(service_context)
 
-    result = service.update()
+    result = item_service.update()
 
     assert result.success is True
     write_ids_mock.assert_not_called()

--- a/tests/cli/core/price_lists/services/test_pricelist_service.py
+++ b/tests/cli/core/price_lists/services/test_pricelist_service.py
@@ -21,7 +21,14 @@ def service_context(mock_mpt_api_client, price_list_new_file, active_vendor_acco
     )
 
 
-def test_create_price_list(mocker, service_context, mpt_price_list_data, price_list_data_from_dict):
+@pytest.fixture
+def price_list_service(service_context):
+    return PriceListService(service_context)
+
+
+def test_create_price_list(
+    mocker, service_context, price_list_service, mpt_price_list_data, price_list_data_from_dict
+):
     read_data_mock = mocker.patch.object(
         service_context.file_manager, "read_data", return_value=price_list_data_from_dict
     )
@@ -32,9 +39,8 @@ def test_create_price_list(mocker, service_context, mpt_price_list_data, price_l
     )
     write_ids_mock = mocker.patch.object(service_context.file_manager, "write_ids")
     stats_spy = mocker.spy(service_context.stats, "add_synced")
-    service = PriceListService(service_context)
 
-    result = service.create()
+    result = price_list_service.create()
 
     assert result.success is True
     read_data_mock.assert_called_once()
@@ -43,7 +49,9 @@ def test_create_price_list(mocker, service_context, mpt_price_list_data, price_l
     api_post_mock.assert_called_once()
 
 
-def test_create_price_list_error(mocker, service_context, price_list_data_from_dict):
+def test_create_price_list_error(
+    mocker, service_context, price_list_service, price_list_data_from_dict
+):
     read_data_mock = mocker.patch.object(
         service_context.file_manager, "read_data", return_value=price_list_data_from_dict
     )
@@ -54,9 +62,8 @@ def test_create_price_list_error(mocker, service_context, price_list_data_from_d
     )
     file_handler_write_mock = mocker.patch.object(service_context.file_manager, "write_error")
     stats_spy = mocker.spy(service_context.stats, "add_error")
-    service = PriceListService(service_context)
 
-    result = service.create()
+    result = price_list_service.create()
 
     assert result.success is False
     assert result.errors == ["API Error with response body Error creating price list"]
@@ -67,13 +74,12 @@ def test_create_price_list_error(mocker, service_context, price_list_data_from_d
     file_handler_write_mock.assert_called_once()
 
 
-def test_export(mocker, service_context, mpt_price_list_data):
+def test_export(mocker, service_context, price_list_service, mpt_price_list_data):
     get_mock = mocker.patch.object(service_context.api, "get", return_value=mpt_price_list_data)
     create_tab_mock = mocker.patch.object(service_context.file_manager, "create_tab")
     add_mock = mocker.patch.object(service_context.file_manager, "add")
-    service = PriceListService(service_context)
 
-    result = service.export({"price_list_id": "fake_id"})
+    result = price_list_service.export({"price_list_id": "fake_id"})
 
     assert result.success is True
     get_mock.assert_called()
@@ -81,15 +87,14 @@ def test_export(mocker, service_context, mpt_price_list_data):
     add_mock.assert_called_once()
 
 
-def test_export_mpt_error(mocker, service_context):
+def test_export_mpt_error(mocker, service_context, price_list_service):
     get_mock = mocker.patch.object(
         service_context.api, "get", side_effect=MPTAPIError("API Error", "Error retrieving item")
     )
     create_tab_spy = mocker.spy(service_context.file_manager, "create_tab")
     add_spy = mocker.spy(service_context.file_manager, "add")
-    service = PriceListService(service_context)
 
-    result = service.export({"price_list_id": "fake_id"})
+    result = price_list_service.export({"price_list_id": "fake_id"})
 
     assert result.success is False
     get_mock.assert_called_once()
@@ -97,7 +102,9 @@ def test_export_mpt_error(mocker, service_context):
     add_spy.assert_not_called()
 
 
-def test_retrieve_price_list(mocker, service_context, price_list_data_from_dict):
+def test_retrieve_price_list(
+    mocker, service_context, price_list_service, price_list_data_from_dict
+):
     read_data_mock = mocker.patch.object(
         service_context.file_manager, "read_data", return_value=price_list_data_from_dict
     )
@@ -106,9 +113,8 @@ def test_retrieve_price_list(mocker, service_context, price_list_data_from_dict)
         "exists",
         return_value=True,
     )
-    service = PriceListService(service_context)
 
-    result = service.retrieve()
+    result = price_list_service.retrieve()
 
     assert result.success is True
     assert result.model == price_list_data_from_dict
@@ -116,44 +122,43 @@ def test_retrieve_price_list(mocker, service_context, price_list_data_from_dict)
     api_exists_mock.assert_called_once()
 
 
-def test_retrieve_price_list_not_found(mocker, service_context):
+def test_retrieve_price_list_not_found(mocker, service_context, price_list_service):
     mocker.patch.object(
         service_context.api, "exists", side_effect=MPTAPIError("Not Found", "Pricelist not found")
     )
     file_handler_write_mock = mocker.patch.object(service_context.file_manager, "write_error")
-    service = PriceListService(service_context)
 
-    result = service.retrieve()
+    result = price_list_service.retrieve()
 
     assert not result.success
     assert len(result.errors) > 0
     file_handler_write_mock.assert_called_once()
 
 
-def test_retrieve_from_mpt(mocker, service_context, mpt_price_list_data, price_list_data_from_json):
+def test_retrieve_from_mpt(
+    mocker, service_context, price_list_service, mpt_price_list_data, price_list_data_from_json
+):
     api_get_mock = mocker.patch.object(
         service_context.api,
         "get",
         return_value=mpt_price_list_data,
     )
-    service = PriceListService(service_context)
 
-    result = service.retrieve_from_mpt(price_list_data_from_json.id)
+    result = price_list_service.retrieve_from_mpt(price_list_data_from_json.id)
 
     assert result.success is True
     assert result.model == price_list_data_from_json
     api_get_mock.assert_called_once_with(price_list_data_from_json.id)
 
 
-def test_retrieve_from_mpt_error(mocker, service_context):
+def test_retrieve_from_mpt_error(mocker, service_context, price_list_service):
     api_get_mock = mocker.patch.object(
         service_context.api,
         "get",
         side_effect=MPTAPIError("API Error", "Error retrieving item"),
     )
-    service = PriceListService(service_context)
 
-    result = service.retrieve_from_mpt("fake_id")
+    result = price_list_service.retrieve_from_mpt("fake_id")
 
     assert result.success is False
     assert len(result.errors) > 0
@@ -161,14 +166,13 @@ def test_retrieve_from_mpt_error(mocker, service_context):
     api_get_mock.assert_called_once_with("fake_id")
 
 
-def test_update_price_list(mocker, service_context, price_list_data_from_dict):
+def test_update_price_list(mocker, service_context, price_list_service, price_list_data_from_dict):
     read_data_mock = mocker.patch.object(
         service_context.file_manager, "read_data", return_value=price_list_data_from_dict
     )
     api_update_mock = mocker.patch.object(service_context.api, "update")
-    service = PriceListService(service_context)
 
-    result = service.update()
+    result = price_list_service.update()
 
     assert result.success is True
     assert result.model is not None
@@ -176,7 +180,9 @@ def test_update_price_list(mocker, service_context, price_list_data_from_dict):
     api_update_mock.assert_called_once()
 
 
-def test_update_price_list_error(mocker, service_context, price_list_data_from_dict):
+def test_update_price_list_error(
+    mocker, service_context, price_list_service, price_list_data_from_dict
+):
     read_data_mock = mocker.patch.object(
         service_context.file_manager, "read_data", return_value=price_list_data_from_dict
     )
@@ -187,9 +193,8 @@ def test_update_price_list_error(mocker, service_context, price_list_data_from_d
     )
     stats_spy = mocker.spy(service_context.stats, "add_error")
     file_handler_write_mock = mocker.patch.object(service_context.file_manager, "write_error")
-    service = PriceListService(service_context)
 
-    result = service.update()
+    result = price_list_service.update()
 
     assert result.success is False
     assert result.errors == ["API Error with response body Error updating price list"]

--- a/tests/cli/core/products/conftest.py
+++ b/tests/cli/core/products/conftest.py
@@ -29,11 +29,15 @@ def product_container_mock(mocker, account_container_mock):
     container.item_service.override(MagicMock(ItemService))
     container.item_group_service.override(MagicMock(ItemGroupService))
     container.parameter_group_service.override(MagicMock(ParameterGroupService))
-    container.agreement_parameters_service.override(MagicMock(ParametersService))
-    container.asset_parameters_service.override(MagicMock(ParametersService))
-    container.item_parameters_service.override(MagicMock(ParametersService))
-    container.request_parameters_service.override(MagicMock(ParametersService))
-    container.subscription_parameters_service.override(MagicMock(ParametersService))
+    parameter_service_providers = (
+        container.agreement_parameters_service,
+        container.asset_parameters_service,
+        container.item_parameters_service,
+        container.request_parameters_service,
+        container.subscription_parameters_service,
+    )
+    for service_provider in parameter_service_providers:
+        service_provider.override(MagicMock(ParametersService))
     container.template_service.override(MagicMock(TemplateService))
     export_mock = mocker.patch("cli.core.products.app.export.ProductContainer", autospec=True)
     export_mock.return_value = container

--- a/tests/cli/core/products/services/test_item_service.py
+++ b/tests/cli/core/products/services/test_item_service.py
@@ -22,7 +22,14 @@ def service_context(mock_mpt_api_client, product_file_path, active_vendor_accoun
     )
 
 
-def test_update_item_create(mocker, service_context, item_data_from_dict, mpt_item_data):
+@pytest.fixture
+def item_service(service_context):
+    return ItemService(service_context)
+
+
+def test_update_item_create(
+    mocker, service_context, item_service, item_data_from_dict, mpt_item_data
+):
     item_data_from_dict.action = ItemActionEnum.CREATE
     mocker.patch.object(
         service_context.file_manager, "read_data", return_value=[item_data_from_dict]
@@ -35,9 +42,8 @@ def test_update_item_create(mocker, service_context, item_data_from_dict, mpt_it
     write_ids_mock = mocker.patch.object(service_context.file_manager, "write_ids")
     update_spy = mocker.spy(service_context.api, "update")
     stats_spy = mocker.spy(service_context.stats, "add_synced")
-    service = ItemService(service_context)
 
-    result = service.update()
+    result = item_service.update()
 
     assert result.success is True
     assert result.model is None
@@ -49,7 +55,9 @@ def test_update_item_create(mocker, service_context, item_data_from_dict, mpt_it
     stats_spy.assert_called_once_with(TAB_ITEMS)
 
 
-def test_update_item_create_missing_unit_name(mocker, service_context, item_data_from_dict):
+def test_update_item_create_missing_unit_name(
+    mocker, service_context, item_service, item_data_from_dict
+):
     item_data_from_dict.action = ItemActionEnum.CREATE
     item_data_from_dict.unit_name = None
     mocker.patch.object(
@@ -57,9 +65,8 @@ def test_update_item_create_missing_unit_name(mocker, service_context, item_data
     )
     write_error_mock = mocker.patch.object(service_context.file_manager, "write_error")
     add_error_spy = mocker.spy(service_context.stats, "add_error")
-    service = ItemService(service_context)
 
-    result = service.update()
+    result = item_service.update()
 
     assert result.success is False
     assert service_context.stats.tabs["Items"]["error"] == 1
@@ -67,7 +74,7 @@ def test_update_item_create_missing_unit_name(mocker, service_context, item_data
     add_error_spy.assert_called_once_with(TAB_ITEMS)
 
 
-def test_update_item_create_error(mocker, service_context, item_data_from_dict):
+def test_update_item_create_error(mocker, service_context, item_service, item_data_from_dict):
     item_data_from_dict.action = ItemActionEnum.CREATE
     mocker.patch.object(
         service_context.file_manager, "read_data", return_value=[item_data_from_dict]
@@ -82,9 +89,8 @@ def test_update_item_create_error(mocker, service_context, item_data_from_dict):
     write_error_mock = mocker.patch.object(service_context.file_manager, "write_error")
     update_spy = mocker.spy(service_context.api, "update")
     add_error_spy = mocker.spy(service_context.stats, "add_error")
-    service = ItemService(service_context)
 
-    result = service.update()
+    result = item_service.update()
 
     assert result.success is False
     assert service_context.stats.tabs["Items"]["error"] == 1
@@ -95,15 +101,16 @@ def test_update_item_create_error(mocker, service_context, item_data_from_dict):
     add_error_spy.assert_called_once_with(TAB_ITEMS)
 
 
-def test_update_item_skip(mocker, service_context, item_data_from_dict, mpt_item_data):
+def test_update_item_skip(
+    mocker, service_context, item_service, item_data_from_dict, mpt_item_data
+):
     item_data_from_dict.action = ItemActionEnum.SKIP
     mocker.patch.object(
         service_context.file_manager, "read_data", return_value=[item_data_from_dict]
     )
     stats_spy = mocker.spy(service_context.stats, "add_skipped")
-    service = ItemService(service_context)
 
-    result = service.update()
+    result = item_service.update()
 
     assert result.success is True
     assert result.model is None
@@ -111,7 +118,9 @@ def test_update_item_skip(mocker, service_context, item_data_from_dict, mpt_item
     stats_spy.assert_called_once_with(TAB_ITEMS)
 
 
-def test_update_item_publish(mocker, service_context, item_data_from_dict, mpt_item_data):
+def test_update_item_publish(
+    mocker, service_context, item_service, item_data_from_dict, mpt_item_data
+):
     item_data_from_dict.action = ItemActionEnum.PUBLISH
     mocker.patch.object(
         service_context.file_manager, "read_data", return_value=[item_data_from_dict]
@@ -119,9 +128,8 @@ def test_update_item_publish(mocker, service_context, item_data_from_dict, mpt_i
     post_action_mock = mocker.patch.object(service_context.api, "post_action")
     write_ids_mock = mocker.patch.object(service_context.file_manager, "write_ids")
     stats_spy = mocker.spy(service_context.stats, "add_synced")
-    service = ItemService(service_context)
 
-    result = service.update()
+    result = item_service.update()
 
     assert result.success is True
     assert result.model is None
@@ -132,7 +140,7 @@ def test_update_item_publish(mocker, service_context, item_data_from_dict, mpt_i
 
 
 def test_set_new_item_groups(
-    mocker, service_context, item_data_from_dict, item_group_data_from_dict
+    mocker, service_context, item_service, item_data_from_dict, item_group_data_from_dict
 ):
     read_data_mock = mocker.patch.object(
         service_context.file_manager, "read_data", return_value=[item_data_from_dict]
@@ -140,9 +148,8 @@ def test_set_new_item_groups(
     param_group = DataCollectionModel(collection={"old_group_id": item_group_data_from_dict})
     item_data_from_dict.group_id = "old_group_id"
     write_ids_mock = mocker.patch.object(service_context.file_manager, "write_ids")
-    service = ItemService(service_context)
 
-    service.set_new_item_groups(param_group)  # act
+    item_service.set_new_item_groups(param_group)  # act
 
     read_data_mock.assert_called_once()
     write_ids_mock.assert_called_once_with({

--- a/tests/cli/core/products/services/test_product_service.py
+++ b/tests/cli/core/products/services/test_product_service.py
@@ -25,7 +25,12 @@ def service_context(mock_mpt_api_client, product_new_file, active_vendor_account
     )
 
 
-def test_create(mocker, service_context, mpt_product_data, product_data_from_dict):
+@pytest.fixture
+def product_service(service_context):
+    return ProductService(service_context)
+
+
+def test_create(mocker, service_context, product_service, mpt_product_data, product_data_from_dict):
     read_data_mock = mocker.patch.object(
         service_context.file_manager, "read_data", return_value=product_data_from_dict
     )
@@ -33,9 +38,8 @@ def test_create(mocker, service_context, mpt_product_data, product_data_from_dic
     api_update_mock = mocker.patch.object(service_context.api, "update")
     write_id_mock = mocker.patch.object(service_context.file_manager, "write_ids")
     stats_spy = mocker.spy(service_context.stats, "add_synced")
-    service = ProductService(service_context)
 
-    result = service.create()
+    result = product_service.create()
 
     assert result.success is True
     read_data_mock.assert_called_once()
@@ -45,7 +49,7 @@ def test_create(mocker, service_context, mpt_product_data, product_data_from_dic
     api_update_mock.assert_called_once()
 
 
-def test_create_post_error(mocker, service_context, product_data_from_dict):
+def test_create_post_error(mocker, service_context, product_service, product_data_from_dict):
     read_data_mock = mocker.patch.object(
         service_context.file_manager, "read_data", return_value=product_data_from_dict
     )
@@ -56,11 +60,10 @@ def test_create_post_error(mocker, service_context, product_data_from_dict):
     )
     file_handler_write_mock = mocker.patch.object(service_context.file_manager, "write_error")
     stats_spy = mocker.spy(service_context.stats, "add_error")
-    service = ProductService(service_context)
 
-    result = service.create()
+    result = product_service.create()
 
-    assert result.success is False
+    assert not result.success
     assert result.errors == ["API Error with response body Error creating product"]
     assert result.model is None
     stats_spy.assert_called_once_with(TAB_GENERAL)
@@ -69,7 +72,9 @@ def test_create_post_error(mocker, service_context, product_data_from_dict):
     file_handler_write_mock.assert_called_once()
 
 
-def test_create_update_error(mocker, service_context, mpt_product_data, product_data_from_dict):
+def test_create_update_error(
+    mocker, service_context, product_service, mpt_product_data, product_data_from_dict
+):
     read_data_mock = mocker.patch.object(
         service_context.file_manager, "read_data", return_value=product_data_from_dict
     )
@@ -81,9 +86,8 @@ def test_create_update_error(mocker, service_context, mpt_product_data, product_
     )
     file_handler_write_mock = mocker.patch.object(service_context.file_manager, "write_error")
     stats_spy = mocker.spy(service_context.stats, "add_error")
-    service = ProductService(service_context)
 
-    result = service.create()
+    result = product_service.create()
 
     assert result.success is False
     assert result.errors == ["API Error with response body Error creating product"]
@@ -95,15 +99,14 @@ def test_create_update_error(mocker, service_context, mpt_product_data, product_
     file_handler_write_mock.assert_called_once()
 
 
-def test_export(mocker, service_context, mpt_product_data):
+def test_export(mocker, service_context, product_service, mpt_product_data):
     get_mock = mocker.patch.object(service_context.api, "get", return_value=mpt_product_data)
     create_tab_mock = mocker.patch.object(service_context.file_manager, "create_tab")
     add_mock = mocker.patch.object(service_context.file_manager, "add")
     settings_create_tab_mock = mocker.patch.object(SettingsExcelFileManager, "create_tab")
     settings_file_manager_add_mock = mocker.patch.object(SettingsExcelFileManager, "add")
-    service = ProductService(service_context)
 
-    result = service.export({"product_id": "fake_id"})
+    result = product_service.export({"product_id": "fake_id"})
 
     assert result.success is True
     get_mock.assert_called()
@@ -113,15 +116,14 @@ def test_export(mocker, service_context, mpt_product_data):
     settings_file_manager_add_mock.assert_called_once()
 
 
-def test_export_mpt_error(mocker, service_context):
+def test_export_mpt_error(mocker, service_context, product_service):
     get_mock = mocker.patch.object(
         service_context.api, "get", side_effect=MPTAPIError("API Error", "Error retrieving item")
     )
     create_tab_spy = mocker.spy(service_context.file_manager, "create_tab")
     add_spy = mocker.spy(service_context.file_manager, "add")
-    service = ProductService(service_context)
 
-    result = service.export({"product_id": "fake_id"})
+    result = product_service.export({"product_id": "fake_id"})
 
     assert result.success is False
     get_mock.assert_called_once()
@@ -129,29 +131,27 @@ def test_export_mpt_error(mocker, service_context):
     add_spy.assert_not_called()
 
 
-def test_validate_definition(mocker, service_context):
+def test_validate_definition(mocker, service_context, product_service):
     mocker.patch.object(service_context.file_manager, "check_required_tabs")
     mocker.patch.object(service_context.file_manager, "check_required_fields_by_section")
-    service = ProductService(service_context)
 
-    result = service.validate_definition()
+    result = product_service.validate_definition()
 
     assert result.success is True
     assert result.errors == []
     assert result.model is None
 
 
-def test_validate_definition_file_doesnt_exist(mocker, service_context):
+def test_validate_definition_file_doesnt_exist(mocker, service_context, product_service):
     mocker.patch.object(service_context.file_manager.file_handler, "exists", return_value=False)
-    service = ProductService(service_context)
 
-    result = service.validate_definition()
+    result = product_service.validate_definition()
 
     assert result.success is False
     assert result.errors == ["Provided file path doesn't exist"]
 
 
-def test_validate_definition_missing_tabs(mocker, service_context):
+def test_validate_definition_missing_tabs(mocker, service_context, product_service):
     mocker.patch.object(
         service_context.file_manager,
         "check_required_tabs",
@@ -161,9 +161,8 @@ def test_validate_definition_missing_tabs(mocker, service_context):
         service_context.file_manager, "check_required_fields_by_section"
     )
     stats_spy = mocker.spy(service_context.stats.errors, "add_msg")
-    service = ProductService(service_context)
 
-    result = service.validate_definition()
+    result = product_service.validate_definition()
 
     assert result.success is False
     assert result.errors == ["('Required tabs missing', ['Tab1', 'Tab2'])"]
@@ -174,7 +173,7 @@ def test_validate_definition_missing_tabs(mocker, service_context):
     check_required_fields_by_section_spy.assert_not_called()
 
 
-def test_validate_definition_missing_fields(mocker, service_context):
+def test_validate_definition_missing_fields(mocker, service_context, product_service):
     check_required_tabs_mock = mocker.patch.object(
         service_context.file_manager, "check_required_tabs"
     )
@@ -184,9 +183,8 @@ def test_validate_definition_missing_fields(mocker, service_context):
         side_effect=RequiredFieldsError("Required fields missing", ["Field1", "Field2"]),
     )
     stats_spy = mocker.spy(service_context.stats.errors, "add_msg")
-    service = ProductService(service_context)
 
-    result = service.validate_definition()
+    result = product_service.validate_definition()
 
     assert result.success is False
     assert result.errors == ["('Required fields missing', ['Field1', 'Field2'])"]
@@ -197,7 +195,7 @@ def test_validate_definition_missing_fields(mocker, service_context):
     check_required_tabs_mock.assert_called_once()
 
 
-def test_retrieve(mocker, service_context, product_data_from_dict):
+def test_retrieve(mocker, service_context, product_service, product_data_from_dict):
     read_data_mock = mocker.patch.object(
         service_context.file_manager, "read_data", return_value=product_data_from_dict
     )
@@ -206,9 +204,8 @@ def test_retrieve(mocker, service_context, product_data_from_dict):
         "exists",
         return_value=True,
     )
-    service = ProductService(service_context)
 
-    result = service.retrieve()
+    result = product_service.retrieve()
 
     assert result.success is True
     assert result.model == product_data_from_dict
@@ -216,14 +213,13 @@ def test_retrieve(mocker, service_context, product_data_from_dict):
     api_exists_mock.assert_called_once()
 
 
-def test_retrieve_empty(mocker, service_context):
+def test_retrieve_empty(mocker, service_context, product_service):
     read_data_mock = mocker.patch.object(
         service_context.file_manager, "read_data", return_value=Mock(ProductData, id=None)
     )
     api_exists_mock = mocker.spy(service_context.api, "exists")
-    service = ProductService(service_context)
 
-    result = service.retrieve()
+    result = product_service.retrieve()
 
     assert result.success is True
     assert result.model is None
@@ -231,14 +227,13 @@ def test_retrieve_empty(mocker, service_context):
     api_exists_mock.assert_not_called()
 
 
-def test_retrieve_not_found(mocker, service_context):
+def test_retrieve_not_found(mocker, service_context, product_service):
     mocker.patch.object(
         service_context.api, "exists", side_effect=MPTAPIError("Not Found", "Product not found")
     )
     file_handler_write_mock = mocker.patch.object(service_context.file_manager, "write_error")
-    service = ProductService(service_context)
 
-    result = service.retrieve()
+    result = product_service.retrieve()
 
     assert not result.success
     assert len(result.errors) > 0
@@ -246,30 +241,30 @@ def test_retrieve_not_found(mocker, service_context):
 
 
 @freeze_time("2025-05-30")
-def test_retrieve_from_mpt(mocker, service_context, mpt_product_data, product_data_from_json):
+def test_retrieve_from_mpt(
+    mocker, service_context, product_service, mpt_product_data, product_data_from_json
+):
     api_get_mock = mocker.patch.object(
         service_context.api,
         "get",
         return_value=mpt_product_data,
     )
-    service = ProductService(service_context)
 
-    result = service.retrieve_from_mpt(product_data_from_json.id)
+    result = product_service.retrieve_from_mpt(product_data_from_json.id)
 
     assert result.success is True
     assert result.model == product_data_from_json
     api_get_mock.assert_called_once_with(product_data_from_json.id)
 
 
-def test_retrieve_from_mpt_error(mocker, service_context):
+def test_retrieve_from_mpt_error(mocker, service_context, product_service):
     api_get_mock = mocker.patch.object(
         service_context.api,
         "get",
         side_effect=MPTAPIError("API Error", "Error retrieving item"),
     )
-    service = ProductService(service_context)
 
-    result = service.retrieve_from_mpt("fake_id")
+    result = product_service.retrieve_from_mpt("fake_id")
 
     assert result.success is False
     assert len(result.errors) > 0
@@ -277,7 +272,7 @@ def test_retrieve_from_mpt_error(mocker, service_context):
     api_get_mock.assert_called_once_with("fake_id")
 
 
-def test_update(mocker, service_context, product_data_from_dict):
+def test_update(mocker, service_context, product_service, product_data_from_dict):
     read_data_mock = mocker.patch.object(
         service_context.file_manager, "read_data", return_value=product_data_from_dict
     )
@@ -285,9 +280,8 @@ def test_update(mocker, service_context, product_data_from_dict):
         SettingsExcelFileManager, "read_data", return_value=iter([product_data_from_dict.settings])
     )
     api_update_mock = mocker.patch.object(service_context.api, "update")
-    service = ProductService(service_context)
 
-    result = service.update()
+    result = product_service.update()
 
     assert result.success is True
     assert result.model is not None
@@ -301,7 +295,7 @@ def test_update(mocker, service_context, product_data_from_dict):
     api_update_mock.assert_called_once_with(product_data_from_dict.id, expected_data)
 
 
-def test_update_error(mocker, service_context, product_data_from_dict):
+def test_update_error(mocker, service_context, product_service, product_data_from_dict):
     read_data_mock = mocker.patch.object(
         service_context.file_manager, "read_data", return_value=Mock(id=None)
     )
@@ -315,9 +309,8 @@ def test_update_error(mocker, service_context, product_data_from_dict):
     )
     stats_spy = mocker.spy(service_context.stats, "add_error")
     file_handler_write_mock = mocker.patch.object(service_context.file_manager, "write_error")
-    service = ProductService(service_context)
 
-    result = service.update()
+    result = product_service.update()
 
     assert result.success is False
     assert result.errors == ["API Error with response body Error updating product"]

--- a/tests/cli/core/products/services/test_related_components_base_service.py
+++ b/tests/cli/core/products/services/test_related_components_base_service.py
@@ -64,17 +64,23 @@ def service_context(mocker, active_vendor_account):
     )
 
 
-def test_create(mocker, service_context, mpt_agreement_parameter_data):
+@pytest.fixture
+def related_components_service(service_context):
+    return FakeRelatedComponentsService(service_context)
+
+
+def test_create(mocker, service_context, related_components_service, mpt_agreement_parameter_data):
     data_model_mock = FakeDataModel()
     new_item_mock = {"id": "new_fake_id"}
     mocker.patch.object(service_context.file_manager, "read_data", return_value=[data_model_mock])
     post_mock = mocker.patch.object(service_context.api, "post", return_value=new_item_mock)
     write_ids_mock = mocker.patch.object(service_context.file_manager, "write_ids")
     stats_mock = mocker.patch.object(service_context.stats, "add_synced")
-    service = FakeRelatedComponentsService(service_context)
-    prepare_data_model_to_create_spy = mocker.spy(service, "prepare_data_model_to_create")
+    prepare_data_model_to_create_spy = mocker.spy(
+        related_components_service, "prepare_data_model_to_create"
+    )
 
-    result = service.create()
+    result = related_components_service.create()
 
     assert result.success is True
     assert result.model is None
@@ -85,7 +91,9 @@ def test_create(mocker, service_context, mpt_agreement_parameter_data):
     prepare_data_model_to_create_spy.assert_called_once()
 
 
-def test_create_api_error(mocker, service_context, parameters_data_from_dict):
+def test_create_api_error(
+    mocker, service_context, related_components_service, parameters_data_from_dict
+):
     mocker.patch.object(service_context.file_manager, "read_data", return_value=[FakeDataModel()])
     post_mock = mocker.patch.object(
         service_context.api,
@@ -94,9 +102,8 @@ def test_create_api_error(mocker, service_context, parameters_data_from_dict):
     )
     write_error_mock = mocker.patch.object(service_context.file_manager, "write_error")
     add_error_mock = mocker.patch.object(service_context.stats, "add_error")
-    service = FakeRelatedComponentsService(service_context)
 
-    result = service.create()
+    result = related_components_service.create()
 
     assert result.success is False
     assert len(result.errors) == 1
@@ -105,14 +112,13 @@ def test_create_api_error(mocker, service_context, parameters_data_from_dict):
     add_error_mock.assert_called_once_with("fake_tab_name")
 
 
-def test_export(mocker, service_context, mpt_agreement_parameter_data):
+def test_export(mocker, service_context, related_components_service, mpt_agreement_parameter_data):
     create_data_mock = mocker.patch.object(service_context.file_manager, "create_tab")
     response_payload = {"meta": {"offset": 0, "limit": 100, "total": 0}, "data": []}
     api_list_mock = mocker.patch.object(service_context.api, "list", return_value=response_payload)
     add_mock = mocker.patch.object(service_context.file_manager, "add")
-    service = FakeRelatedComponentsService(service_context)
 
-    result = service.export()
+    result = related_components_service.export()
 
     assert result.success is True
     assert result.model is None
@@ -121,7 +127,9 @@ def test_export(mocker, service_context, mpt_agreement_parameter_data):
     add_mock.assert_called_once()
 
 
-def test_export_error(mocker, service_context, mpt_agreement_parameter_data):
+def test_export_error(
+    mocker, service_context, related_components_service, mpt_agreement_parameter_data
+):
     create_data_mock = mocker.patch.object(service_context.file_manager, "create_tab")
     api_list_mock = mocker.patch.object(
         service_context.api,
@@ -131,9 +139,8 @@ def test_export_error(mocker, service_context, mpt_agreement_parameter_data):
     write_error_mock = mocker.patch.object(service_context.file_manager, "write_error")
     add_error_mock = mocker.patch.object(service_context.stats, "add_error")
     add_spy = mocker.spy(service_context.file_manager, "add")
-    service = FakeRelatedComponentsService(service_context)
 
-    result = service.export()
+    result = related_components_service.export()
 
     assert result.success is False
     assert result.errors == ["API Error with response body Error getting parameters"]
@@ -144,7 +151,7 @@ def test_export_error(mocker, service_context, mpt_agreement_parameter_data):
     add_spy.assert_not_called()
 
 
-def test_update_action_skip(mocker, service_context):
+def test_update_action_skip(mocker, service_context, related_components_service):
     mocker.patch.object(
         service_context.file_manager,
         "read_data",
@@ -152,16 +159,15 @@ def test_update_action_skip(mocker, service_context):
     )
     mocker.patch.object(FakeDataModel, "to_skip", new=True)
     stats_skipped_mock = mocker.patch.object(service_context.stats, "add_skipped")
-    service = FakeRelatedComponentsService(service_context)
 
-    result = service.update()
+    result = related_components_service.update()
 
     assert result.success is True
     assert result.model is None
     stats_skipped_mock.assert_called_once_with("fake_tab_name")
 
 
-def test_update_action_create(mocker, service_context):
+def test_update_action_create(mocker, service_context, related_components_service):
     mocker.patch.object(
         service_context.file_manager,
         "read_data",
@@ -173,9 +179,8 @@ def test_update_action_create(mocker, service_context):
     api_post_mock = mocker.patch.object(
         service_context.api, "post", return_value={"id": "new_fake_id"}
     )
-    service = FakeRelatedComponentsService(service_context)
 
-    result = service.update()
+    result = related_components_service.update()
 
     assert result.success is True
     assert result.model is None
@@ -184,7 +189,7 @@ def test_update_action_create(mocker, service_context):
     api_post_mock.assert_called_once_with(json={"id": "create_id"})
 
 
-def test_update_action_delete(mocker, service_context):
+def test_update_action_delete(mocker, service_context, related_components_service):
     mocker.patch.object(
         service_context.file_manager,
         "read_data",
@@ -193,9 +198,8 @@ def test_update_action_delete(mocker, service_context):
     mocker.patch.object(FakeDataModel, "to_skip", new=False)
     file_handler_error_mock = mocker.patch.object(service_context.file_manager, "write_error")
     stats_error_mock = mocker.patch.object(service_context.stats, "add_error")
-    service = FakeRelatedComponentsService(service_context)
 
-    result = service.update()
+    result = related_components_service.update()
 
     assert result.success is False
     file_handler_error_mock.assert_called_once_with(
@@ -204,7 +208,7 @@ def test_update_action_delete(mocker, service_context):
     stats_error_mock.assert_called_once_with("fake_tab_name")
 
 
-def test_update_action_update(mocker, service_context):
+def test_update_action_update(mocker, service_context, related_components_service):
     mocker.patch.object(
         service_context.file_manager,
         "read_data",
@@ -214,9 +218,8 @@ def test_update_action_update(mocker, service_context):
     write_ids_mock = mocker.patch.object(service_context.file_manager, "write_ids")
     stats_synced_mock = mocker.patch.object(service_context.stats, "add_synced")
     api_update_mock = mocker.patch.object(service_context.api, "update")
-    service = FakeRelatedComponentsService(service_context)
 
-    result = service.update()
+    result = related_components_service.update()
 
     assert result.success is True
     assert result.model is None
@@ -225,7 +228,7 @@ def test_update_action_update(mocker, service_context):
     api_update_mock.assert_called_once_with("update_id", {"id": "update_id"})
 
 
-def test_update_action_value_error(mocker, service_context):
+def test_update_action_value_error(mocker, service_context, related_components_service):
     mocker.patch.object(
         service_context.file_manager,
         "read_data",
@@ -234,16 +237,15 @@ def test_update_action_value_error(mocker, service_context):
     mocker.patch.object(FakeDataModel, "to_skip", new=False)
     file_handler_error_mock = mocker.patch.object(service_context.file_manager, "write_error")
     stats_error_mock = mocker.patch.object(service_context.stats, "add_error")
-    service = FakeRelatedComponentsService(service_context)
 
-    result = service.update()
+    result = related_components_service.update()
 
     assert result.success is False
     file_handler_error_mock.assert_called_once_with("Invalid action: FakeAction", "error_action_id")
     stats_error_mock.assert_called_once_with("fake_tab_name")
 
 
-def test_update_action_api_error(mocker, service_context):
+def test_update_action_api_error(mocker, service_context, related_components_service):
     mocker.patch.object(
         service_context.file_manager,
         "read_data",
@@ -255,9 +257,8 @@ def test_update_action_api_error(mocker, service_context):
     api_update_mock = mocker.patch.object(
         service_context.api, "update", side_effect=MPTAPIError("API Error", "Error updating item")
     )
-    service = FakeRelatedComponentsService(service_context)
 
-    result = service.update()
+    result = related_components_service.update()
 
     assert result.success is False
     file_handler_error_mock.assert_called_once_with(


### PR DESCRIPTION
🤖 **AI-generated PR** — Please review carefully.

## Summary
- Remove WPS204 from the test ignore list.
- Refactor repeated test setup into domain-specific fixtures for account paths, stored accounts, MPT resources, and concrete service instances.
- Keep WPS210, WPS213, WPS218, WPS221, and WPS432 ignored for tests; those will be handled separately.

## Validation
- `make check-all`
- `docker compose run --rm app flake8 tests --per-file-ignores="" --format='%(path)s:%(row)d:%(col)d:%(code)s:%(text)s' 2>/dev/null | rg 'WPS204'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-17825](https://softwareone.atlassian.net/browse/MPT-17825)

- Removed WPS204, WPS210, and WPS221 from flake8 test ignores in `pyproject.toml`
- Refactored test setup across accounts, price lists, and products modules by introducing domain-specific pytest fixtures:
  - Added `account_file_path` and `stored_accounts` fixtures in accounts `conftest.py`
  - Added `mpt_resource` and `mpt_api_error_type` fixtures in MPT API tests
  - Added service-level fixtures (`item_service`, `price_list_service`, `product_service`, `related_components_service`) to consolidate repeated test initialization
- Replaced private test helper functions with explicit fixtures and fixture-backed test utilities
- Updated 30+ test function signatures across accounts, MPT, price lists, and products modules to use the new centralized fixtures
- Added targeted `noqa` markers for two intentional WPS221 audit-record parametrization cases
- Simplified test code by removing inline file path construction, JSON parsing, and service instantiation in favor of fixture-provided objects

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softwareone-platform/swo-marketplace-cli/pull/216)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-17825]: https://softwareone.atlassian.net/browse/MPT-17825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ