### PR TITLE
MPT-17825: Remove WPS210 and WPS221 test ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ select = ["AAA", "E999", "WPS"]
 show-source = true
 statistics = false
 per-file-ignores = [
-  "tests/**:WPS202,WPS210,WPS213,WPS218,WPS221,WPS432"
+  "tests/**:WPS202,WPS213,WPS218,WPS432"
 ]
 
 [tool.ruff]

--- a/tests/cli/core/accounts/handlers/test_json_file_handler.py
+++ b/tests/cli/core/accounts/handlers/test_json_file_handler.py
@@ -38,9 +38,8 @@ def test_write_creates_directory_if_not_exists(tmp_path):
     expected_records = [{"id": "test_id", "name": "Test Name"}]
     nonexistent_dir = tmp_path / "nonexistent_dir"
     target_file_path = nonexistent_dir / "accounts.json"
-    json_handler = JsonFileHandler(file_path=target_file_path)
 
-    json_handler.write(expected_records)  # act
+    JsonFileHandler(file_path=target_file_path).write(expected_records)  # act
 
     assert nonexistent_dir.exists()
     assert target_file_path.exists()

--- a/tests/cli/core/mpt/test_flows.py
+++ b/tests/cli/core/mpt/test_flows.py
@@ -6,6 +6,21 @@ from mpt_api_client.exceptions import MPTAPIError as ClientAPIError
 from mpt_api_client.models import Meta, Model, ModelCollection, Pagination
 
 
+class MPTProductResourceFactory:
+    def __init__(self, mocker):
+        self.mocker = mocker
+
+    def __call__(self, product_data):
+        resource = self.mocker.MagicMock(spec=Model)
+        resource.to_dict.return_value = product_data
+        return resource
+
+
+@pytest.fixture
+def mpt_product_resource_factory(mocker):
+    return MPTProductResourceFactory(mocker)
+
+
 @pytest.mark.parametrize(
     "query",
     [
@@ -13,19 +28,18 @@ from mpt_api_client.models import Meta, Model, ModelCollection, Pagination
         "eq(product.id,'PRD-1234-1234')",
     ],
 )
-def test_get_products(mocker, mock_mpt_api_client, mpt_products, query):
-    mock_resources = []
-    for product_data in mpt_products:
-        resource = mocker.MagicMock(spec=Model)
-        resource.to_dict.return_value = product_data
-        mock_resources.append(resource)
+def test_get_products(
+    mocker, mock_mpt_api_client, mpt_products, query, mpt_product_resource_factory
+):
     collection = mocker.MagicMock(spec=ModelCollection)
     collection.meta = mocker.MagicMock(spec=Meta)
     collection.meta.pagination = mocker.MagicMock(spec=Pagination)
     collection.meta.pagination.limit = 10
     collection.meta.pagination.offset = 0
     collection.meta.pagination.total = len(mpt_products)
-    collection.resources = mock_resources
+    collection.resources = [
+        mpt_product_resource_factory(product_data) for product_data in mpt_products
+    ]
     mock_mpt_api_client.catalog.products.fetch_page.return_value = collection
     product_filter = mock_mpt_api_client.catalog.products.filter.return_value
     product_filter.fetch_page.return_value = collection

--- a/tests/cli/core/mpt/test_flows.py
+++ b/tests/cli/core/mpt/test_flows.py
@@ -6,7 +6,7 @@ from mpt_api_client.exceptions import MPTAPIError as ClientAPIError
 from mpt_api_client.models import Meta, Model, ModelCollection, Pagination
 
 
-class MPTProductResourceFactory:
+class FakeMPTProductResourceFactory:
     def __init__(self, mocker):
         self.mocker = mocker
 
@@ -18,7 +18,7 @@ class MPTProductResourceFactory:
 
 @pytest.fixture
 def mpt_product_resource_factory(mocker):
-    return MPTProductResourceFactory(mocker)
+    return FakeMPTProductResourceFactory(mocker)
 
 
 @pytest.mark.parametrize(

--- a/tests/cli/core/price_lists/app/test_sync.py
+++ b/tests/cli/core/price_lists/app/test_sync.py
@@ -74,30 +74,30 @@ def test_sync_price_lists_create(
         autospec=True,
     )
     stats = PriceListStatsCollector()
-    price_list_service_retrieve_mock = mocker.patch.object(
+    mocker.patch.object(
         PriceListService,
         "retrieve",
         return_value=ServiceResult(success=True, model=None, stats=stats),
     )
-    price_list_service_create_mock = mocker.patch.object(
+    mocker.patch.object(
         PriceListService,
         "create",
         return_value=ServiceResult(success=True, model=price_list_data_from_json, stats=stats),
     )
-    item_service_update_mock = mocker.patch.object(
+    mocker.patch.object(
         ItemService,
         "update",
         return_value=ServiceResult(success=True, model=None, stats=stats),
     )
-    price_list_service_update_spy = mocker.spy(PriceListService, "update")
+    mocker.spy(PriceListService, "update")
 
     result = runner.invoke(app, ["sync", str(price_list_file_path)], input="y\ny\n")
 
     assert result.exit_code == 0, result.stdout
-    price_list_service_retrieve_mock.assert_called_once()
-    price_list_service_create_mock.assert_called_once()
-    item_service_update_mock.assert_called_once()
-    price_list_service_update_spy.assert_not_called()
+    PriceListService.retrieve.assert_called_once()
+    PriceListService.create.assert_called_once()
+    ItemService.update.assert_called_once()
+    PriceListService.update.assert_not_called()
 
 
 def test_sync_price_lists_create_error(
@@ -136,23 +136,23 @@ def test_sync_price_lists_retrieve_error(mocker, active_vendor_account, price_li
         autospec=True,
     )
     stats = PriceListStatsCollector()
-    price_list_service_retrieve_mock = mocker.patch.object(
+    mocker.patch.object(
         PriceListService,
         "retrieve",
         return_value=ServiceResult(success=False, model=None, stats=stats),
     )
-    price_list_service_create_spy = mocker.spy(PriceListService, "create")
-    price_list_service_update_spy = mocker.spy(PriceListService, "update")
-    item_service_update_spy = mocker.spy(ItemService, "update")
+    mocker.spy(PriceListService, "create")
+    mocker.spy(PriceListService, "update")
+    mocker.spy(ItemService, "update")
 
     result = runner.invoke(app, ["sync", str(price_list_file_path)], input="y\n")
 
     assert result.exit_code == 4
     assert "Price list sync FAILED\n" in strip_ansi(result.stdout)
-    price_list_service_retrieve_mock.assert_called_once()
-    price_list_service_create_spy.assert_not_called()
-    price_list_service_update_spy.assert_not_called()
-    item_service_update_spy.assert_not_called()
+    PriceListService.retrieve.assert_called_once()
+    PriceListService.create.assert_not_called()
+    PriceListService.update.assert_not_called()
+    ItemService.update.assert_not_called()
 
 
 def test_sync_price_lists_update(
@@ -164,30 +164,30 @@ def test_sync_price_lists_update(
         return_value=active_vendor_account,
         autospec=True,
     )
-    price_list_service_retrieve_mock = mocker.patch.object(
+    mocker.patch.object(
         PriceListService,
         "retrieve",
         return_value=ServiceResult(success=True, model=price_list_data_from_json, stats=stats),
     )
-    price_list_service_update_mock = mocker.patch.object(
+    mocker.patch.object(
         PriceListService,
         "update",
         return_value=ServiceResult(success=True, model=price_list_data_from_json, stats=stats),
     )
-    item_service_update_mock = mocker.patch.object(
+    mocker.patch.object(
         ItemService,
         "update",
         return_value=ServiceResult(success=True, model=None, stats=stats),
     )
-    price_list_service_create_spy = mocker.spy(PriceListService, "create")
+    mocker.spy(PriceListService, "create")
 
     result = runner.invoke(app, ["sync", str(price_list_file_path)], input="y\ny\n")
 
     assert result.exit_code == 0, result.stdout
-    price_list_service_retrieve_mock.assert_called_once()
-    price_list_service_update_mock.assert_called_once_with()
-    item_service_update_mock.assert_called_once()
-    price_list_service_create_spy.assert_not_called()
+    PriceListService.retrieve.assert_called_once()
+    PriceListService.update.assert_called_once_with()
+    ItemService.update.assert_called_once()
+    PriceListService.create.assert_not_called()
 
 
 def test_sync_price_lists_update_error(

--- a/tests/cli/core/price_lists/services/test_item_service.py
+++ b/tests/cli/core/price_lists/services/test_item_service.py
@@ -44,21 +44,19 @@ def test_export(mocker, service_context, item_service, mpt_item_data):
 
 
 def test_export_paginates_until_total(mocker, service_context, item_service, mpt_item_data):
-    create_tab_mock = mocker.patch.object(service_context.file_manager, "create_tab")
-    add_mock = mocker.patch.object(service_context.file_manager, "add")
+    mocker.patch.object(service_context.file_manager, "create_tab")
+    mocker.patch.object(service_context.file_manager, "add")
     first_page = {"data": [mpt_item_data], "meta": {"offset": 0, "limit": 1, "total": 2}}
     second_page = {"data": [mpt_item_data], "meta": {"offset": 1, "limit": 1, "total": 2}}
-    api_list_mock = mocker.patch.object(
-        service_context.api, "list", side_effect=[first_page, second_page]
-    )
+    mocker.patch.object(service_context.api, "list", side_effect=[first_page, second_page])
 
     result = item_service.export()
 
     assert result.success is True
-    create_tab_mock.assert_called_once()
-    assert add_mock.call_count == 2
-    assert api_list_mock.call_count == 2
-    first_call, second_call = api_list_mock.call_args_list
+    service_context.file_manager.create_tab.assert_called_once()
+    assert service_context.file_manager.add.call_count == 2
+    assert service_context.api.list.call_count == 2
+    first_call, second_call = service_context.api.list.call_args_list
     assert first_call.args[0]["offset"] == 0
     assert second_call.args[0]["offset"] > first_call.args[0]["offset"]
 

--- a/tests/cli/core/products/app/test_export.py
+++ b/tests/cli/core/products/app/test_export.py
@@ -44,7 +44,7 @@ EXPECTED_PRODUCT_ID_ROWS = (
 )
 
 
-class ModelCollectionFactory:
+class FakeModelCollectionFactory:
     def __init__(self, mocker):
         self.mocker = mocker
 
@@ -65,7 +65,7 @@ class ModelCollectionFactory:
 
 @pytest.fixture
 def model_collection_factory(mocker):
-    return ModelCollectionFactory(mocker)
+    return FakeModelCollectionFactory(mocker)
 
 
 @pytest.fixture

--- a/tests/cli/core/products/app/test_export.py
+++ b/tests/cli/core/products/app/test_export.py
@@ -9,22 +9,133 @@ from openpyxl.reader.excel import load_workbook
 from typer.testing import CliRunner
 
 runner = CliRunner()
+PRODUCT_ID = "PRD-0232-2541"
+EXPECTED_PRODUCT_SHEETS = (
+    "General",
+    "Settings",
+    "Items",
+    "Items Groups",
+    "Parameters Groups",
+    "Agreements Parameters",
+    "Assets Parameters",
+    "Item Parameters",
+    "Request Parameters",
+    "Subscription Parameters",
+    "Templates",
+)
+EXPECTED_PRODUCT_MAIN_SHEET_VALUES = (
+    ("General", 12, (("A1", "General Information"), ("A2", "Product ID"), ("B2", PRODUCT_ID))),
+    (
+        "Settings",
+        12,
+        (("A1", "Setting"), ("A2", "Change order validation (draft)"), ("C2", "Enabled")),
+    ),
+)
+EXPECTED_PRODUCT_ID_ROWS = (
+    ("Items", "ITM-0232-2541-0001"),
+    ("Items Groups", "IGR-0232-2541-0001"),
+    ("Parameters Groups", "PGR-0232-2541-0002"),
+    ("Agreements Parameters", "PAR-0232-2541-0001"),
+    ("Assets Parameters", "PAR-0232-2541-0027"),
+    ("Item Parameters", "PAR-0232-2541-0022"),
+    ("Request Parameters", "PAR-0232-2541-0012"),
+    ("Subscription Parameters", "PAR-0232-2541-0023"),
+    ("Templates", "TPL-0232-2541-0005"),
+)
 
 
-def make_collection(mocker, data_list):
-    collection = mocker.MagicMock(spec=ModelCollection)
-    collection.meta = mocker.MagicMock(spec=ClientMeta)
-    collection.meta.pagination = mocker.MagicMock(spec=Pagination)
-    collection.meta.pagination.limit = 100
-    collection.meta.pagination.offset = 0
-    collection.meta.pagination.total = len(data_list)
-    resources = []
-    for resource_data in data_list:
-        resource = mocker.MagicMock(spec=Model)
-        resource.to_dict.return_value = resource_data
-        resources.append(resource)
-    collection.resources = resources
-    return collection
+class ModelCollectionFactory:
+    def __init__(self, mocker):
+        self.mocker = mocker
+
+    def __call__(self, data_list):
+        collection = self.mocker.MagicMock(spec=ModelCollection)
+        collection.meta = self.mocker.MagicMock(spec=ClientMeta)
+        collection.meta.pagination = self.mocker.MagicMock(spec=Pagination)
+        collection.meta.pagination.limit = 100
+        collection.meta.pagination.offset = 0
+        collection.meta.pagination.total = len(data_list)
+        collection.resources = []
+        for resource_data in data_list:
+            resource = self.mocker.MagicMock(spec=Model)
+            resource.to_dict.return_value = resource_data
+            collection.resources.append(resource)
+        return collection
+
+
+@pytest.fixture
+def model_collection_factory(mocker):
+    return ModelCollectionFactory(mocker)
+
+
+@pytest.fixture
+def product_catalog(account_container_mock):
+    return account_container_mock.api_mpt_client().catalog.products
+
+
+@pytest.fixture
+def catalog_items(account_container_mock):
+    return account_container_mock.api_mpt_client().catalog.items
+
+
+@pytest.fixture
+def product_parameters(product_catalog):
+    return product_catalog.parameters.return_value
+
+
+@pytest.fixture
+def export_product_resource(mocker, product_catalog, mpt_product_data):
+    product_resource = mocker.MagicMock(spec=Model)
+    product_resource.to_dict.return_value = mpt_product_data
+    product_catalog.get.return_value = product_resource
+
+
+@pytest.fixture
+def export_product_related_resources(
+    catalog_items,
+    product_catalog,
+    product_parameters,
+    product_related_data,
+    model_collection_factory,
+):
+    items_select = catalog_items.filter.return_value.select
+    item_groups_select = product_catalog.item_groups.return_value.select
+    parameter_groups_select = product_catalog.parameter_groups.return_value.select
+    parameters_select = product_parameters.filter.return_value.select
+    templates_select = product_catalog.templates.return_value.select
+    items_select.return_value.fetch_page.return_value = model_collection_factory([
+        product_related_data["mpt_item"]
+    ])
+    item_groups_select.return_value.fetch_page.return_value = model_collection_factory([
+        product_related_data["mpt_item_group"]
+    ])
+    parameter_groups_select.return_value.fetch_page.return_value = model_collection_factory([
+        product_related_data["mpt_parameter_group"]
+    ])
+    parameters_select.return_value.fetch_page.side_effect = [
+        model_collection_factory([product_related_data["mpt_agreement_parameter"]]),
+        model_collection_factory([product_related_data["mpt_asset_parameter"]]),
+        model_collection_factory([product_related_data["mpt_item_parameter"]]),
+        model_collection_factory([product_related_data["mpt_request_parameter"]]),
+        model_collection_factory([product_related_data["mpt_subscription_parameter"]]),
+    ]
+    templates_select.return_value.fetch_page.return_value = model_collection_factory([
+        product_related_data["mpt_template"]
+    ])
+
+
+@pytest.fixture
+def exported_product_workbook(tmp_path, export_product_resource, export_product_related_resources):
+    result = runner.invoke(
+        product_app, ["export", PRODUCT_ID, "--out", str(tmp_path)], input="y\ny\n"
+    )
+    product_path = tmp_path / f"{PRODUCT_ID}.xlsx"
+
+    assert result.exit_code == 0, result.stdout
+    assert product_path.exists()
+    workbook = load_workbook(product_path)
+    yield workbook
+    workbook.close()
 
 
 def test_export_skipped_when_user_declines(mocker, product_container_mock):
@@ -55,14 +166,10 @@ def test_export_product_error_exporting_product(mocker, product_container_mock):
     assert result.exit_code == 3, result.stdout
 
 
-def test_export_product_overwrites_existing_files(
-    mocker,
-    tmp_path,
-    product_container_mock,
-):
-    exists_mock = mocker.patch.object(Path, "exists", return_value=True)
-    unlink_mock = mocker.patch.object(Path, "unlink", return_value=True)
-    replace_mock = mocker.patch.object(Path, "replace")
+def test_export_product_overwrites_existing_files(mocker, tmp_path, product_container_mock):
+    mocker.patch.object(Path, "exists", return_value=True)
+    mocker.patch.object(Path, "unlink", return_value=True)
+    mocker.patch.object(Path, "replace")
     product_container_mock.stats.override(mocker.Mock(spec=ProductStatsCollector, has_errors=False))
     product_id = "PRD-1234"
     tmp_file = tmp_path / f"{product_id}.xlsx"
@@ -75,119 +182,35 @@ def test_export_product_overwrites_existing_files(
     )
 
     assert result.exit_code == 0, result.stdout
-    exists_mock.assert_called()
+    Path.exists.assert_called()
     assert tmp_file.exists()
-    unlink_mock.assert_called()
-    replace_mock.assert_called_once()
+    Path.unlink.assert_called()
+    Path.replace.assert_called_once()
     product_container_mock.product_service().export.assert_called_once()
 
 
 @pytest.mark.integration
-def test_export_product(
-    tmp_path,
-    mocker,
-    account_container_mock,
-    mpt_product_data,
-    product_related_data,
-):
-    mock_api_client = account_container_mock.api_mpt_client()
-    product_resource = mocker.MagicMock(spec=Model)
-    product_resource.to_dict.return_value = mpt_product_data
-    mock_api_client.catalog.products.get.return_value = product_resource
-    mock_items = mock_api_client.catalog.items
-    mock_items_select = mock_items.filter.return_value.select.return_value
-    mock_items_select.fetch_page.return_value = make_collection(
-        mocker, [product_related_data["mpt_item"]]
-    )
-    item_groups = mock_api_client.catalog.products.item_groups.return_value
-    item_groups.select.return_value.fetch_page.return_value = make_collection(
-        mocker, [product_related_data["mpt_item_group"]]
-    )
-    parameter_groups = mock_api_client.catalog.products.parameter_groups.return_value
-    parameter_groups.select.return_value.fetch_page.return_value = make_collection(
-        mocker, [product_related_data["mpt_parameter_group"]]
-    )
-    params_service = mock_api_client.catalog.products.parameters.return_value
-    params_service_select = params_service.filter.return_value.select.return_value
-    params_service_select.fetch_page.side_effect = [
-        make_collection(mocker, [product_related_data["mpt_agreement_parameter"]]),
-        make_collection(mocker, [product_related_data["mpt_asset_parameter"]]),
-        make_collection(mocker, [product_related_data["mpt_item_parameter"]]),
-        make_collection(mocker, [product_related_data["mpt_request_parameter"]]),
-        make_collection(mocker, [product_related_data["mpt_subscription_parameter"]]),
-    ]
-    products_templates = mock_api_client.catalog.products.templates.return_value
-    products_templates.select.return_value.fetch_page.return_value = make_collection(
-        mocker, [product_related_data["mpt_template"]]
-    )
-    product_id = "PRD-0232-2541"
+def test_export_product(exported_product_workbook):
+    sheet_names = exported_product_workbook.sheetnames  # act
 
-    result = runner.invoke(
-        product_app, ["export", product_id, "--out", str(tmp_path)], input="y\ny\n"
-    )
+    assert sheet_names == list(EXPECTED_PRODUCT_SHEETS)
 
-    assert result.exit_code == 0, result.stdout
-    product_path = tmp_path / f"{product_id}.xlsx"
-    assert product_path.exists()
-    wb = load_workbook(product_path)
-    expected_sheets = [
-        "General",
-        "Settings",
-        "Items",
-        "Items Groups",
-        "Parameters Groups",
-        "Agreements Parameters",
-        "Assets Parameters",
-        "Item Parameters",
-        "Request Parameters",
-        "Subscription Parameters",
-        "Templates",
-    ]
-    assert wb.sheetnames == expected_sheets
-    general_sheet = wb["General"]
-    assert general_sheet.max_row == 12
-    assert general_sheet["A1"].value == "General Information"
-    assert general_sheet["A2"].value == "Product ID"
-    assert general_sheet["B2"].value == product_id
-    settings_sheet = wb["Settings"]
-    assert settings_sheet.max_row == 12
-    assert settings_sheet["A1"].value == "Setting"
-    assert settings_sheet["A2"].value == "Change order validation (draft)"
-    assert settings_sheet["C2"].value == "Enabled"
-    items_sheet = wb["Items"]
-    assert items_sheet.max_row == 2
-    assert items_sheet["A1"].value == "ID"
-    assert items_sheet["A2"].value == "ITM-0232-2541-0001"
-    items_groups_sheet = wb["Items Groups"]
-    assert items_groups_sheet.max_row == 2
-    assert items_groups_sheet["A1"].value == "ID"
-    assert items_groups_sheet["A2"].value == "IGR-0232-2541-0001"
-    parameters_groups_sheet = wb["Parameters Groups"]
-    assert parameters_groups_sheet.max_row == 2
-    assert parameters_groups_sheet["A1"].value == "ID"
-    assert parameters_groups_sheet["A2"].value == "PGR-0232-2541-0002"
-    agreements_params_sheet = wb["Agreements Parameters"]
-    assert agreements_params_sheet.max_row == 2
-    assert agreements_params_sheet["A1"].value == "ID"
-    assert agreements_params_sheet["A2"].value == "PAR-0232-2541-0001"
-    assets_params_sheet = wb["Assets Parameters"]
-    assert assets_params_sheet.max_row == 2
-    assert assets_params_sheet["A1"].value == "ID"
-    assert assets_params_sheet["A2"].value == "PAR-0232-2541-0027"
-    item_params_sheet = wb["Item Parameters"]
-    assert item_params_sheet.max_row == 2
-    assert item_params_sheet["A1"].value == "ID"
-    assert item_params_sheet["A2"].value == "PAR-0232-2541-0022"
-    request_params_sheet = wb["Request Parameters"]
-    assert request_params_sheet.max_row == 2
-    assert request_params_sheet["A1"].value == "ID"
-    assert request_params_sheet["A2"].value == "PAR-0232-2541-0012"
-    subscription_parameter_sheet = wb["Subscription Parameters"]
-    assert subscription_parameter_sheet.max_row == 2
-    assert subscription_parameter_sheet["A1"].value == "ID"
-    assert subscription_parameter_sheet["A2"].value == "PAR-0232-2541-0023"
-    templates_sheet = wb["Templates"]
-    assert templates_sheet.max_row == 2
-    assert templates_sheet["A1"].value == "ID"
-    assert templates_sheet["A2"].value == "TPL-0232-2541-0005"
-    wb.close()
+
+@pytest.mark.integration
+def test_export_product_main_sheet_values(exported_product_workbook):
+    main_sheet_values = EXPECTED_PRODUCT_MAIN_SHEET_VALUES  # act
+
+    for sheet_values in main_sheet_values:
+        assert exported_product_workbook[sheet_values[0]].max_row == sheet_values[1]
+        for cell_name, expected_value in sheet_values[2]:
+            assert exported_product_workbook[sheet_values[0]][cell_name].value == expected_value
+
+
+@pytest.mark.integration
+def test_export_product_related_sheet_values(exported_product_workbook):
+    id_rows = EXPECTED_PRODUCT_ID_ROWS  # act
+
+    for id_row in id_rows:
+        assert exported_product_workbook[id_row[0]].max_row == 2
+        assert exported_product_workbook[id_row[0]]["A1"].value == "ID"
+        assert exported_product_workbook[id_row[0]]["A2"].value == id_row[1]

--- a/tests/cli/core/products/app/test_sync.py
+++ b/tests/cli/core/products/app/test_sync.py
@@ -1,3 +1,4 @@
+import pytest
 from cli.core.models import DataCollectionModel
 from cli.core.products import app as product_app
 from cli.core.services.service_result import ServiceResult
@@ -7,8 +8,21 @@ from typer.testing import CliRunner
 runner = CliRunner()
 
 
-def _stub_product_service(mocker, product_container_mock, product_data_from_dict):
-    """Set up the product service mock with validate_definition + retrieve."""
+class ServiceCreateResultFactory:
+    def __init__(self, mocker):
+        self.mocker = mocker
+
+    def __call__(self, collection_data):
+        return ServiceResult(
+            success=True,
+            model=None,
+            collection=DataCollectionModel(collection={"fake_id": collection_data}),
+            stats=self.mocker.Mock(),
+        )
+
+
+@pytest.fixture
+def existing_product_sync(mocker, product_container_mock, product_data_from_dict):
     product_container_mock.product_service().validate_definition.return_value = ServiceResult(
         success=True, model=None, stats=mocker.Mock()
     )
@@ -17,14 +31,14 @@ def _stub_product_service(mocker, product_container_mock, product_data_from_dict
     )
 
 
-def _stub_service_create(mocker, service_mock, collection_data):
-    """Set up a service create() mock with a DataCollectionModel collection."""
-    service_mock.create.return_value = ServiceResult(
-        success=True,
-        model=None,
-        collection=DataCollectionModel(collection={"fake_id": collection_data}),
-        stats=mocker.Mock(),
-    )
+@pytest.fixture
+def service_create_result_factory(mocker):
+    return ServiceCreateResultFactory(mocker)
+
+
+@pytest.fixture
+def existing_product_file(product_new_file, existing_product_sync):
+    return product_new_file
 
 
 def test_sync_not_valid_definition(mocker, product_container_mock):
@@ -51,11 +65,10 @@ def test_sync_with_dry_run(mocker, product_container_mock):
 
 
 def test_sync_product_update_runs_update_flow(
-    mocker, product_container_mock, product_data_from_dict
+    mocker, product_container_mock, existing_product_sync
 ):
     mocker.patch.object(ProductStatsCollector, "has_errors", new=False)
     mocker.patch("cli.core.products.app.sync.stats_table_renderer.render", return_value="")
-    _stub_product_service(mocker, product_container_mock, product_data_from_dict)
 
     result = runner.invoke(product_app, ["sync", "fake_file.xlsx"], input="y\n")
 
@@ -73,9 +86,8 @@ def test_sync_product_update_runs_update_flow(
     product_container_mock.subscription_parameters_service().update.assert_called_once()
 
 
-def test_sync_product_update_with_errors(mocker, product_container_mock, product_data_from_dict):
+def test_sync_product_update_with_errors(mocker, product_container_mock, existing_product_sync):
     mocker.patch.object(ProductStatsCollector, "has_errors", new=True)
-    _stub_product_service(mocker, product_container_mock, product_data_from_dict)
 
     result = runner.invoke(product_app, ["sync", "fake_file.xlsx"], input="y\n")
 
@@ -84,23 +96,26 @@ def test_sync_product_update_with_errors(mocker, product_container_mock, product
 
 
 def test_sync_product_force_create_runs(
-    mocker, product_container_mock, product_new_file, product_data_from_dict, product_related_data
+    mocker,
+    product_container_mock,
+    existing_product_file,
+    product_related_data,
+    service_create_result_factory,
 ):
     mocker.patch.object(ProductStatsCollector, "has_errors", new=False)
     render_mock = mocker.patch(
         "cli.core.products.app.sync.stats_table_renderer.render", return_value=""
     )
-    _stub_product_service(mocker, product_container_mock, product_data_from_dict)
     product_container_mock.product_service().create.return_value = ServiceResult(
-        success=True, model=product_data_from_dict, stats=mocker.Mock()
+        success=True,
+        model=product_container_mock.product_service().retrieve.return_value.model,
+        stats=mocker.Mock(),
     )
-    _stub_service_create(
-        mocker, product_container_mock.item_group_service(), product_related_data["item_group"]
+    product_container_mock.item_group_service().create.return_value = service_create_result_factory(
+        product_related_data["item_group"]
     )
-    _stub_service_create(
-        mocker,
-        product_container_mock.parameter_group_service(),
-        product_related_data["parameter_group"],
+    product_container_mock.parameter_group_service().create.return_value = (
+        service_create_result_factory(product_related_data["parameter_group"])
     )
     for parameter_service in (
         product_container_mock.agreement_parameters_service(),
@@ -109,11 +124,13 @@ def test_sync_product_force_create_runs(
         product_container_mock.request_parameters_service(),
         product_container_mock.subscription_parameters_service(),
     ):
-        _stub_service_create(mocker, parameter_service, product_related_data["parameters"])
+        parameter_service.create.return_value = service_create_result_factory(
+            product_related_data["parameters"]
+        )
 
     result = runner.invoke(
         product_app,
-        ["sync", "--force-create", str(product_new_file)],
+        ["sync", "--force-create", str(existing_product_file)],
         input="y\n",
     )
 
@@ -126,7 +143,11 @@ def test_sync_product_force_create_runs(
 
 
 def test_sync_product_no_product_runs_create_flow(
-    mocker, product_new_file, product_container_mock, product_related_data
+    mocker,
+    product_new_file,
+    product_container_mock,
+    product_related_data,
+    service_create_result_factory,
 ):
     mocker.patch.object(ProductStatsCollector, "has_errors", new=False)
     render_mock = mocker.patch(
@@ -141,13 +162,11 @@ def test_sync_product_no_product_runs_create_flow(
     product_container_mock.product_service().create.return_value = ServiceResult(
         success=True, model=product_related_data["template"], stats=mocker.Mock()
     )
-    _stub_service_create(
-        mocker, product_container_mock.item_group_service(), product_related_data["item_group"]
+    product_container_mock.item_group_service().create.return_value = service_create_result_factory(
+        product_related_data["item_group"]
     )
-    _stub_service_create(
-        mocker,
-        product_container_mock.parameter_group_service(),
-        product_related_data["parameter_group"],
+    product_container_mock.parameter_group_service().create.return_value = (
+        service_create_result_factory(product_related_data["parameter_group"])
     )
     for parameter_service in (
         product_container_mock.agreement_parameters_service(),
@@ -156,7 +175,9 @@ def test_sync_product_no_product_runs_create_flow(
         product_container_mock.request_parameters_service(),
         product_container_mock.subscription_parameters_service(),
     ):
-        _stub_service_create(mocker, parameter_service, product_related_data["parameters"])
+        parameter_service.create.return_value = service_create_result_factory(
+            product_related_data["parameters"]
+        )
     add_collection_spy = mocker.spy(DataCollectionModel, "add")
 
     result = runner.invoke(product_app, ["sync", str(product_new_file)], input="y\n")

--- a/tests/cli/core/products/services/test_item_service.py
+++ b/tests/cli/core/products/services/test_item_service.py
@@ -34,14 +34,14 @@ def test_update_item_create(
     mocker.patch.object(
         service_context.file_manager, "read_data", return_value=[item_data_from_dict]
     )
-    post_mock = mocker.patch.object(service_context.api, "post", return_value=mpt_item_data)
+    mocker.patch.object(service_context.api, "post", return_value=mpt_item_data)
     search_uom_by_name_mock = mocker.patch(
         "cli.core.products.services.item_service.search_uom_by_name",
         return_value=Uom(id="fake_unit_id", name="User"),
     )
-    write_ids_mock = mocker.patch.object(service_context.file_manager, "write_ids")
-    update_spy = mocker.spy(service_context.api, "update")
-    stats_spy = mocker.spy(service_context.stats, "add_synced")
+    mocker.patch.object(service_context.file_manager, "write_ids")
+    mocker.spy(service_context.api, "update")
+    mocker.spy(service_context.stats, "add_synced")
 
     result = item_service.update()
 
@@ -49,10 +49,12 @@ def test_update_item_create(
     assert result.model is None
     assert service_context.stats.tabs["Items"]["synced"] == 1
     search_uom_by_name_mock.assert_called_once()
-    post_mock.assert_called_once()
-    write_ids_mock.assert_called_once_with({item_data_from_dict.coordinate: mpt_item_data["id"]})
-    update_spy.assert_not_called()
-    stats_spy.assert_called_once_with(TAB_ITEMS)
+    service_context.api.post.assert_called_once()
+    service_context.file_manager.write_ids.assert_called_once_with({
+        item_data_from_dict.coordinate: mpt_item_data["id"]
+    })
+    service_context.api.update.assert_not_called()
+    service_context.stats.add_synced.assert_called_once_with(TAB_ITEMS)
 
 
 def test_update_item_create_missing_unit_name(
@@ -79,26 +81,26 @@ def test_update_item_create_error(mocker, service_context, item_service, item_da
     mocker.patch.object(
         service_context.file_manager, "read_data", return_value=[item_data_from_dict]
     )
-    post_mock = mocker.patch.object(
+    mocker.patch.object(
         service_context.api, "post", side_effect=MPTAPIError("API Error", "Error updating item")
     )
     search_uom_by_name_mock = mocker.patch(
         "cli.core.products.services.item_service.search_uom_by_name",
         return_value=Uom(id="fake_unit_id", name="User"),
     )
-    write_error_mock = mocker.patch.object(service_context.file_manager, "write_error")
-    update_spy = mocker.spy(service_context.api, "update")
-    add_error_spy = mocker.spy(service_context.stats, "add_error")
+    mocker.patch.object(service_context.file_manager, "write_error")
+    mocker.spy(service_context.api, "update")
+    mocker.spy(service_context.stats, "add_error")
 
     result = item_service.update()
 
     assert result.success is False
     assert service_context.stats.tabs["Items"]["error"] == 1
     search_uom_by_name_mock.assert_called_once()
-    post_mock.assert_called_once()
-    write_error_mock.assert_called_once()
-    update_spy.assert_not_called()
-    add_error_spy.assert_called_once_with(TAB_ITEMS)
+    service_context.api.post.assert_called_once()
+    service_context.file_manager.write_error.assert_called_once()
+    service_context.api.update.assert_not_called()
+    service_context.stats.add_error.assert_called_once_with(TAB_ITEMS)
 
 
 def test_update_item_skip(

--- a/tests/cli/core/products/services/test_product_service.py
+++ b/tests/cli/core/products/services/test_product_service.py
@@ -31,22 +31,24 @@ def product_service(service_context):
 
 
 def test_create(mocker, service_context, product_service, mpt_product_data, product_data_from_dict):
-    read_data_mock = mocker.patch.object(
+    mocker.patch.object(
         service_context.file_manager, "read_data", return_value=product_data_from_dict
     )
-    api_post_mock = mocker.patch.object(service_context.api, "post", return_value=mpt_product_data)
-    api_update_mock = mocker.patch.object(service_context.api, "update")
-    write_id_mock = mocker.patch.object(service_context.file_manager, "write_ids")
-    stats_spy = mocker.spy(service_context.stats, "add_synced")
+    mocker.patch.object(service_context.api, "post", return_value=mpt_product_data)
+    mocker.patch.object(service_context.api, "update")
+    mocker.patch.object(service_context.file_manager, "write_ids")
+    mocker.spy(service_context.stats, "add_synced")
 
     result = product_service.create()
 
     assert result.success is True
-    read_data_mock.assert_called_once()
-    stats_spy.assert_called_once_with(TAB_GENERAL)
-    write_id_mock.assert_called_once_with({"B3": product_data_from_dict.id})
-    api_post_mock.assert_called_once()
-    api_update_mock.assert_called_once()
+    service_context.file_manager.read_data.assert_called_once()
+    service_context.stats.add_synced.assert_called_once_with(TAB_GENERAL)
+    service_context.file_manager.write_ids.assert_called_once_with({
+        "B3": product_data_from_dict.id
+    })
+    service_context.api.post.assert_called_once()
+    service_context.api.update.assert_called_once()
 
 
 def test_create_post_error(mocker, service_context, product_service, product_data_from_dict):
@@ -75,45 +77,45 @@ def test_create_post_error(mocker, service_context, product_service, product_dat
 def test_create_update_error(
     mocker, service_context, product_service, mpt_product_data, product_data_from_dict
 ):
-    read_data_mock = mocker.patch.object(
+    mocker.patch.object(
         service_context.file_manager, "read_data", return_value=product_data_from_dict
     )
-    api_post_mock = mocker.patch.object(service_context.api, "post", return_value=mpt_product_data)
-    api_update_mock = mocker.patch.object(
+    mocker.patch.object(service_context.api, "post", return_value=mpt_product_data)
+    mocker.patch.object(
         service_context.api,
         "update",
         side_effect=MPTAPIError("API Error", "Error creating product"),
     )
-    file_handler_write_mock = mocker.patch.object(service_context.file_manager, "write_error")
-    stats_spy = mocker.spy(service_context.stats, "add_error")
+    mocker.patch.object(service_context.file_manager, "write_error")
+    mocker.spy(service_context.stats, "add_error")
 
     result = product_service.create()
 
     assert result.success is False
     assert result.errors == ["API Error with response body Error creating product"]
     assert result.model is None
-    stats_spy.assert_called_once_with(TAB_GENERAL)
-    read_data_mock.assert_called_once()
-    api_post_mock.assert_called_once()
-    api_update_mock.assert_called_once()
-    file_handler_write_mock.assert_called_once()
+    service_context.stats.add_error.assert_called_once_with(TAB_GENERAL)
+    service_context.file_manager.read_data.assert_called_once()
+    service_context.api.post.assert_called_once()
+    service_context.api.update.assert_called_once()
+    service_context.file_manager.write_error.assert_called_once()
 
 
 def test_export(mocker, service_context, product_service, mpt_product_data):
-    get_mock = mocker.patch.object(service_context.api, "get", return_value=mpt_product_data)
-    create_tab_mock = mocker.patch.object(service_context.file_manager, "create_tab")
-    add_mock = mocker.patch.object(service_context.file_manager, "add")
-    settings_create_tab_mock = mocker.patch.object(SettingsExcelFileManager, "create_tab")
-    settings_file_manager_add_mock = mocker.patch.object(SettingsExcelFileManager, "add")
+    mocker.patch.object(service_context.api, "get", return_value=mpt_product_data)
+    mocker.patch.object(service_context.file_manager, "create_tab")
+    mocker.patch.object(service_context.file_manager, "add")
+    mocker.patch.object(SettingsExcelFileManager, "create_tab")
+    mocker.patch.object(SettingsExcelFileManager, "add")
 
     result = product_service.export({"product_id": "fake_id"})
 
     assert result.success is True
-    get_mock.assert_called()
-    create_tab_mock.assert_called_once()
-    add_mock.assert_called_once()
-    settings_create_tab_mock.assert_called_once()
-    settings_file_manager_add_mock.assert_called_once()
+    service_context.api.get.assert_called()
+    service_context.file_manager.create_tab.assert_called_once()
+    service_context.file_manager.add.assert_called_once()
+    SettingsExcelFileManager.create_tab.assert_called_once()
+    SettingsExcelFileManager.add.assert_called_once()
 
 
 def test_export_mpt_error(mocker, service_context, product_service):
@@ -296,27 +298,25 @@ def test_update(mocker, service_context, product_service, product_data_from_dict
 
 
 def test_update_error(mocker, service_context, product_service, product_data_from_dict):
-    read_data_mock = mocker.patch.object(
-        service_context.file_manager, "read_data", return_value=Mock(id=None)
-    )
-    read_settings_data_mock = mocker.patch.object(
+    mocker.patch.object(service_context.file_manager, "read_data", return_value=Mock(id=None))
+    mocker.patch.object(
         SettingsExcelFileManager, "read_data", return_value=iter([product_data_from_dict.settings])
     )
-    api_update_mock = mocker.patch.object(
+    mocker.patch.object(
         service_context.api,
         "update",
         side_effect=MPTAPIError("API Error", "Error updating product"),
     )
-    stats_spy = mocker.spy(service_context.stats, "add_error")
-    file_handler_write_mock = mocker.patch.object(service_context.file_manager, "write_error")
+    mocker.spy(service_context.stats, "add_error")
+    mocker.patch.object(service_context.file_manager, "write_error")
 
     result = product_service.update()
 
     assert result.success is False
     assert result.errors == ["API Error with response body Error updating product"]
     assert result.model is None
-    read_data_mock.assert_called_once()
-    read_settings_data_mock.assert_called_once()
-    stats_spy.assert_called_once_with(TAB_GENERAL)
-    file_handler_write_mock.assert_called_once()
-    api_update_mock.assert_called_once()
+    service_context.file_manager.read_data.assert_called_once()
+    SettingsExcelFileManager.read_data.assert_called_once()
+    service_context.stats.add_error.assert_called_once_with(TAB_GENERAL)
+    service_context.file_manager.write_error.assert_called_once()
+    service_context.api.update.assert_called_once()

--- a/tests/cli/core/products/services/test_related_components_base_service.py
+++ b/tests/cli/core/products/services/test_related_components_base_service.py
@@ -73,9 +73,9 @@ def test_create(mocker, service_context, related_components_service, mpt_agreeme
     data_model_mock = FakeDataModel()
     new_item_mock = {"id": "new_fake_id"}
     mocker.patch.object(service_context.file_manager, "read_data", return_value=[data_model_mock])
-    post_mock = mocker.patch.object(service_context.api, "post", return_value=new_item_mock)
-    write_ids_mock = mocker.patch.object(service_context.file_manager, "write_ids")
-    stats_mock = mocker.patch.object(service_context.stats, "add_synced")
+    mocker.patch.object(service_context.api, "post", return_value=new_item_mock)
+    mocker.patch.object(service_context.file_manager, "write_ids")
+    mocker.patch.object(service_context.stats, "add_synced")
     prepare_data_model_to_create_spy = mocker.spy(
         related_components_service, "prepare_data_model_to_create"
     )
@@ -85,9 +85,11 @@ def test_create(mocker, service_context, related_components_service, mpt_agreeme
     assert result.success is True
     assert result.model is None
     assert isinstance(result.collection, DataCollectionModel)
-    write_ids_mock.assert_called_once_with({"fake_coordinate": "new_fake_id"})
-    post_mock.assert_called_once_with(json={"id": "fake_id"})
-    stats_mock.assert_called_once_with("fake_tab_name")
+    service_context.file_manager.write_ids.assert_called_once_with({
+        "fake_coordinate": "new_fake_id"
+    })
+    service_context.api.post.assert_called_once_with(json={"id": "fake_id"})
+    service_context.stats.add_synced.assert_called_once_with("fake_tab_name")
     prepare_data_model_to_create_spy.assert_called_once()
 
 
@@ -130,25 +132,25 @@ def test_export(mocker, service_context, related_components_service, mpt_agreeme
 def test_export_error(
     mocker, service_context, related_components_service, mpt_agreement_parameter_data
 ):
-    create_data_mock = mocker.patch.object(service_context.file_manager, "create_tab")
-    api_list_mock = mocker.patch.object(
+    mocker.patch.object(service_context.file_manager, "create_tab")
+    mocker.patch.object(
         service_context.api,
         "list",
         side_effect=MPTAPIError("API Error", "Error getting parameters"),
     )
-    write_error_mock = mocker.patch.object(service_context.file_manager, "write_error")
-    add_error_mock = mocker.patch.object(service_context.stats, "add_error")
-    add_spy = mocker.spy(service_context.file_manager, "add")
+    mocker.patch.object(service_context.file_manager, "write_error")
+    mocker.patch.object(service_context.stats, "add_error")
+    mocker.spy(service_context.file_manager, "add")
 
     result = related_components_service.export()
 
     assert result.success is False
     assert result.errors == ["API Error with response body Error getting parameters"]
-    create_data_mock.assert_called_once()
-    api_list_mock.assert_called_once()
-    add_error_mock.assert_called_once_with("fake_tab_name")
-    write_error_mock.assert_called_once()
-    add_spy.assert_not_called()
+    service_context.file_manager.create_tab.assert_called_once()
+    service_context.api.list.assert_called_once()
+    service_context.stats.add_error.assert_called_once_with("fake_tab_name")
+    service_context.file_manager.write_error.assert_called_once()
+    service_context.file_manager.add.assert_not_called()
 
 
 def test_update_action_skip(mocker, service_context, related_components_service):

--- a/tests/cli/core/test_error_wrappers.py
+++ b/tests/cli/core/test_error_wrappers.py
@@ -5,13 +5,9 @@ from cli.core.error_wrappers import ApiErrorWrapper, HttpErrorWrapper
 from mpt_api_client.exceptions import MPTHttpError
 
 
-def _build_runtime_error(request_msg, response_body):
-    return RuntimeError(f"{request_msg}|{response_body}")
-
-
 @pytest.fixture
 def error_factory():
-    return _build_runtime_error
+    return lambda request_msg, response_body: RuntimeError(f"{request_msg}|{response_body}")
 
 
 @pytest.fixture

--- a/tests/cli/core/test_errors.py
+++ b/tests/cli/core/test_errors.py
@@ -3,16 +3,8 @@ from cli.core.errors import MPTAPIError, wrap_http_error
 from requests import RequestException, Response
 
 
-def _raise_connection_error() -> None:
-    raise RequestException("Connection error")
-
-
-def _raise_bad_request(response: Response) -> None:
-    raise RequestException("Bad Request", response=response)
-
-
-def test_wrap_http_error_no_response():
-    wrapped = wrap_http_error(_raise_connection_error)
+def test_wrap_http_error_no_response(mocker):
+    wrapped = wrap_http_error(mocker.Mock(side_effect=RequestException("Connection error")))
 
     with pytest.raises(MPTAPIError) as error:
         wrapped()
@@ -25,7 +17,9 @@ def test_wrap_http_error_non_bad_request(mocker):
     response.status_code = 500
     response.content = b"server error"
     response.text = "server error"
-    wrapped = wrap_http_error(lambda: _raise_bad_request(response))
+    wrapped = wrap_http_error(
+        mocker.Mock(side_effect=RequestException("Bad Request", response=response))
+    )
 
     with pytest.raises(MPTAPIError) as error:
         wrapped()
@@ -37,7 +31,9 @@ def test_wrap_http_error_bad_request_fields(mocker):
     response = mocker.Mock(spec=Response)
     response.status_code = 400
     response.json.return_value = {"errors": {"name": ["is required"]}}
-    wrapped = wrap_http_error(lambda: _raise_bad_request(response))
+    wrapped = wrap_http_error(
+        mocker.Mock(side_effect=RequestException("Bad Request", response=response))
+    )
 
     with pytest.raises(MPTAPIError) as error:
         wrapped()
@@ -51,7 +47,9 @@ def test_wrap_http_error_bad_request_no_fields(mocker):
     response.json.return_value = {"message": "Invalid payload"}
     response.content = b"invalid payload content"
     response.text = "invalid payload content"
-    wrapped = wrap_http_error(lambda: _raise_bad_request(response))
+    wrapped = wrap_http_error(
+        mocker.Mock(side_effect=RequestException("Bad Request", response=response))
+    )
 
     with pytest.raises(MPTAPIError) as error:
         wrapped()
@@ -65,7 +63,9 @@ def test_wrap_http_error_bad_request_invalid_json(mocker):
     response.json.side_effect = ValueError("invalid json")
     response.content = b"invalid response content"
     response.text = "invalid response content"
-    wrapped = wrap_http_error(lambda: _raise_bad_request(response))
+    wrapped = wrap_http_error(
+        mocker.Mock(side_effect=RequestException("Bad Request", response=response))
+    )
 
     with pytest.raises(MPTAPIError) as error:
         wrapped()
@@ -77,7 +77,9 @@ def test_wrap_http_error_non_list_details(mocker):
     response = mocker.Mock(spec=Response)
     response.status_code = 400
     response.json.return_value = {"errors": {"name": "is required"}}
-    wrapped = wrap_http_error(lambda: _raise_bad_request(response))
+    wrapped = wrap_http_error(
+        mocker.Mock(side_effect=RequestException("Bad Request", response=response))
+    )
 
     with pytest.raises(MPTAPIError) as error:
         wrapped()
@@ -91,7 +93,9 @@ def test_wrap_http_error_non_dict_payload(mocker):
     response.json.return_value = ["invalid", "payload"]
     response.content = b"invalid payload content"
     response.text = "invalid payload content"
-    wrapped = wrap_http_error(lambda: _raise_bad_request(response))
+    wrapped = wrap_http_error(
+        mocker.Mock(side_effect=RequestException("Bad Request", response=response))
+    )
 
     with pytest.raises(MPTAPIError) as error:
         wrapped()

--- a/tests/cli/plugins/audit_plugin/test_api.py
+++ b/tests/cli/plugins/audit_plugin/test_api.py
@@ -7,11 +7,17 @@ from mpt_api_client import MPTClient, RQLQuery
 from mpt_api_client.models.model import Model
 from typer import Exit
 
+AUDIT_SELECT_FIELDS = ("object", "actor", "details", "documents", "request.api.geolocation")
 
-def _mock_record(mocker, record_data: dict):
-    record = mocker.MagicMock(spec=Model)
-    record.to_dict.return_value = record_data
-    return record
+
+class AuditRecordFactory:
+    def __init__(self, mocker):
+        self.mocker = mocker
+
+    def __call__(self, record_data: dict):
+        record = self.mocker.MagicMock(spec=Model)
+        record.to_dict.return_value = record_data
+        return record
 
 
 @pytest.fixture
@@ -19,7 +25,12 @@ def mock_client(mocker):
     return mocker.Mock(spec=MPTClient)
 
 
-def test_get_audit_trail_successful_retrieval(mock_client, mocker):
+@pytest.fixture
+def audit_record_factory(mocker):
+    return AuditRecordFactory(mocker)
+
+
+def test_get_audit_trail_successful_retrieval(mock_client, audit_record_factory):
     expected_record = {
         "id": "audit123",
         "object": {"id": "obj123"},
@@ -28,15 +39,14 @@ def test_get_audit_trail_successful_retrieval(mock_client, mocker):
     records_options = mock_client.audit.records.options
     filtered = records_options.return_value.filter.return_value
     chain = filtered.select.return_value
-    chain.fetch_page.return_value = [_mock_record(mocker, expected_record)]
+    chain.fetch_page.return_value = [audit_record_factory(expected_record)]
 
     result = get_audit_trail(mock_client, "audit123")
 
-    select_fields = ["object", "actor", "details", "documents", "request.api.geolocation"]
     assert result == expected_record
     records_options.assert_called_once_with(render=True)
     records_options.return_value.filter.assert_called_once_with(RQLQuery(id="audit123"))
-    filtered.select.assert_called_once_with(*select_fields)
+    filtered.select.assert_called_once_with(*AUDIT_SELECT_FIELDS)
     chain.fetch_page.assert_called_once_with(limit=1)
 
 
@@ -59,7 +69,7 @@ def test_get_audit_trail_api_error(mock_client):
         get_audit_trail(mock_client, "audit123")
 
 
-def test_get_audit_records_by_object_retrieval(mock_client, mocker):
+def test_get_audit_records_by_object_retrieval(mock_client, audit_record_factory):
     expected_records = [
         {"id": "audit1", "object": {"id": "obj123"}, "timestamp": "2024-01-01T10:00:00Z"},
         {"id": "audit2", "object": {"id": "obj123"}, "timestamp": "2024-01-01T11:00:00Z"},
@@ -67,16 +77,17 @@ def test_get_audit_records_by_object_retrieval(mock_client, mocker):
     records_options = mock_client.audit.records.options
     filtered = records_options.return_value.filter.return_value
     chain = filtered.order_by.return_value.select.return_value
-    chain.fetch_page.return_value = [_mock_record(mocker, rec) for rec in expected_records]
+    chain.fetch_page.return_value = [
+        audit_record_factory(record_data) for record_data in expected_records
+    ]
 
     result = get_audit_records_by_object(mock_client, "obj123", limit=10)
 
-    select_fields = ["object", "actor", "details", "documents", "request.api.geolocation"]
     assert result == expected_records
     records_options.assert_called_once_with(render=True)
     records_options.return_value.filter.assert_called_once_with(RQLQuery(object__id="obj123"))
     filtered.order_by.assert_called_once_with("-timestamp")
-    filtered.order_by.return_value.select.assert_called_once_with(*select_fields)
+    filtered.order_by.return_value.select.assert_called_once_with(*AUDIT_SELECT_FIELDS)
     chain.fetch_page.assert_called_once_with(limit=10)
 
 
@@ -100,11 +111,11 @@ def test_get_audit_records_by_object_api_error(mock_client):
         get_audit_records_by_object(mock_client, "obj123")
 
 
-def test_get_audit_records_by_object_custom_limit(mock_client, mocker):
+def test_get_audit_records_by_object_custom_limit(mock_client, audit_record_factory):
     records_options = mock_client.audit.records.options
     filtered = records_options.return_value.filter.return_value
     chain = filtered.order_by.return_value.select.return_value
-    chain.fetch_page.return_value = [_mock_record(mocker, {"id": "audit1"})]
+    chain.fetch_page.return_value = [audit_record_factory({"id": "audit1"})]
 
     result = get_audit_records_by_object(mock_client, "obj123", limit=5)
 

--- a/tests/cli/plugins/audit_plugin/test_audit_records.py
+++ b/tests/cli/plugins/audit_plugin/test_audit_records.py
@@ -10,8 +10,8 @@ from cli.plugins.audit_plugin.audit_records import (
     ("input_dict", "expected_result"),
     [
         ({"a": 1, "b": 2}, {"a": 1, "b": 2}),  # simple dict
-        ({"a": {"b": 1, "c": {"d": 2}}}, {"a.b": 1, "a.c.d": 2}),  # nested_dict
-        ({"a": [{"b": 1}, {"c": 2}]}, {"a[0].b": 1, "a[1].c": 2}),  # dict with a list
+        ({"a": {"b": 1, "c": {"d": 2}}}, {"a.b": 1, "a.c.d": 2}),  # noqa: WPS221
+        ({"a": [{"b": 1}, {"c": 2}]}, {"a[0].b": 1, "a[1].c": 2}),  # noqa: WPS221
         ({"a": [1, 2, 3]}, {"a[0]": 1, "a[1]": 2, "a[2]": 3}),  # dict with a primitive list
     ],
 )


### PR DESCRIPTION
🤖 **AI-generated PR** — Please review carefully.

## Summary
- Remove WPS210 and WPS221 from the test ignore list, stacked on the WPS204 cleanup branch.
- Reduce WPS210 local-variable violations in focused tests by moving scenario setup into existing objects, concrete fixtures, or fixture-backed factories.
- Add targeted `noqa: WPS221` markers for the two intentionally dense `flatten_dict` parametrization cases.

## Validation
- `make check`
- `docker compose run --rm app flake8 tests --per-file-ignores="" --format='%(path)s:%(row)d:%(col)d:%(code)s:%(text)s' 2>/dev/null | rg 'WPS204|WPS210|WPS221'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-17825](https://softwareone.atlassian.net/browse/MPT-17825)

- Remove `WPS210` and `WPS221` from the `tests/**` flake8 ignore list in `pyproject.toml`
- Refactor test structure to reduce WPS210 (local variable) violations by moving scenario setup into factory objects and fixtures across multiple test modules
- Add targeted `# noqa: WPS221` markers to intentionally dense parametrization cases in `flatten_dict` tests
- Introduce factory classes (`FakeMPTProductResourceFactory`, `FakeModelCollectionFactory`, `ServiceCreateResultFactory`, `AuditRecordFactory`) to centralize test data construction and reduce inline variable assignments
- Consolidate pytest fixtures for product/service mocking, audit records, and export workbooks to improve test reusability and reduce complexity
- Standardize mock/spy assertion patterns across test modules by using inline patching/spying with direct method assertions instead of storing intermediate mock variables
- Refactor integration tests to use shared fixtures and constants for expected outputs (e.g., `AUDIT_SELECT_FIELDS`, `exported_product_workbook`)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softwareone-platform/swo-marketplace-cli/pull/217)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-17825]: https://softwareone.atlassian.net/browse/MPT-17825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ