### PR TITLE
MPT-17825: Remove WPS213 test ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ select = ["AAA", "E999", "WPS"]
 show-source = true
 statistics = false
 per-file-ignores = [
-  "tests/**:WPS202,WPS213,WPS218,WPS432"
+  "tests/**:WPS202,WPS218,WPS432"
 ]
 
 [tool.ruff]

--- a/tests/cli/core/products/app/test_sync.py
+++ b/tests/cli/core/products/app/test_sync.py
@@ -41,6 +41,13 @@ def existing_product_file(product_new_file, existing_product_sync):
     return product_new_file
 
 
+@pytest.fixture
+def product_update_container(mocker, product_container_mock, existing_product_sync):
+    mocker.patch.object(ProductStatsCollector, "has_errors", new=False)
+    mocker.patch("cli.core.products.app.sync.stats_table_renderer.render", return_value="")
+    return product_container_mock
+
+
 def test_sync_not_valid_definition(mocker, product_container_mock):
     product_container_mock.product_service().validate_definition.return_value = ServiceResult(
         success=False, model=None, stats=mocker.Mock()
@@ -64,26 +71,26 @@ def test_sync_with_dry_run(mocker, product_container_mock):
     product_container_mock.product_service().update.assert_not_called()
 
 
-def test_sync_product_update_runs_update_flow(
-    mocker, product_container_mock, existing_product_sync
-):
-    mocker.patch.object(ProductStatsCollector, "has_errors", new=False)
-    mocker.patch("cli.core.products.app.sync.stats_table_renderer.render", return_value="")
+def test_sync_product_update_runs_update_flow(product_update_container):
+    updated_services = (
+        product_update_container.item_service(),
+        product_update_container.item_group_service(),
+        product_update_container.template_service(),
+        product_update_container.parameter_group_service(),
+        product_update_container.agreement_parameters_service(),
+        product_update_container.asset_parameters_service(),
+        product_update_container.item_parameters_service(),
+        product_update_container.request_parameters_service(),
+        product_update_container.subscription_parameters_service(),
+    )
 
     result = runner.invoke(product_app, ["sync", "fake_file.xlsx"], input="y\n")
 
     assert result.exit_code == 0, result.stdout
     assert "Do you want to update product" in result.stdout
-    product_container_mock.product_service().update.assert_called_once()
-    product_container_mock.item_service().update.assert_called_once()
-    product_container_mock.item_group_service().update.assert_called_once()
-    product_container_mock.template_service().update.assert_called_once()
-    product_container_mock.parameter_group_service().update.assert_called_once()
-    product_container_mock.agreement_parameters_service().update.assert_called_once()
-    product_container_mock.asset_parameters_service().update.assert_called_once()
-    product_container_mock.item_parameters_service().update.assert_called_once()
-    product_container_mock.request_parameters_service().update.assert_called_once()
-    product_container_mock.subscription_parameters_service().update.assert_called_once()
+    product_update_container.product_service().update.assert_called_once()
+    for service in updated_services:
+        service.update.assert_called_once()
 
 
 def test_sync_product_update_with_errors(mocker, product_container_mock, existing_product_sync):

--- a/tests/cli/core/products/services/test_item_service.py
+++ b/tests/cli/core/products/services/test_item_service.py
@@ -27,34 +27,53 @@ def item_service(service_context):
     return ItemService(service_context)
 
 
-def test_update_item_create(
-    mocker, service_context, item_service, item_data_from_dict, mpt_item_data
-):
+@pytest.fixture
+def item_data_to_create(item_data_from_dict):
     item_data_from_dict.action = ItemActionEnum.CREATE
-    mocker.patch.object(
-        service_context.file_manager, "read_data", return_value=[item_data_from_dict]
-    )
-    mocker.patch.object(service_context.api, "post", return_value=mpt_item_data)
-    search_uom_by_name_mock = mocker.patch(
+    return item_data_from_dict
+
+
+@pytest.fixture
+def unit_name_search(mocker):
+    return mocker.patch(
         "cli.core.products.services.item_service.search_uom_by_name",
         return_value=Uom(id="fake_unit_id", name="User"),
     )
-    mocker.patch.object(service_context.file_manager, "write_ids")
-    mocker.spy(service_context.api, "update")
-    mocker.spy(service_context.stats, "add_synced")
+
+
+@pytest.fixture
+def item_create_file_data(mocker, service_context, item_data_to_create):
+    mocker.patch.object(
+        service_context.file_manager, "read_data", return_value=[item_data_to_create]
+    )
+    return service_context
+
+
+@pytest.fixture
+def item_create_update_flow(mocker, item_create_file_data, mpt_item_data):
+    mocker.patch.object(item_create_file_data.api, "post", return_value=mpt_item_data)
+    mocker.patch.object(item_create_file_data.file_manager, "write_ids")
+    mocker.spy(item_create_file_data.api, "update")
+    mocker.spy(item_create_file_data.stats, "add_synced")
+    return item_create_file_data
+
+
+def test_update_item_create(
+    item_create_update_flow, item_service, item_data_to_create, unit_name_search
+):
 
     result = item_service.update()
 
     assert result.success is True
     assert result.model is None
-    assert service_context.stats.tabs["Items"]["synced"] == 1
-    search_uom_by_name_mock.assert_called_once()
-    service_context.api.post.assert_called_once()
-    service_context.file_manager.write_ids.assert_called_once_with({
-        item_data_from_dict.coordinate: mpt_item_data["id"]
+    assert item_create_update_flow.stats.tabs["Items"]["synced"] == 1
+    unit_name_search.assert_called_once()
+    item_create_update_flow.api.post.assert_called_once()
+    item_create_update_flow.file_manager.write_ids.assert_called_once_with({
+        item_data_to_create.coordinate: item_create_update_flow.api.post.return_value["id"]
     })
-    service_context.api.update.assert_not_called()
-    service_context.stats.add_synced.assert_called_once_with(TAB_ITEMS)
+    item_create_update_flow.api.update.assert_not_called()
+    item_create_update_flow.stats.add_synced.assert_called_once_with(TAB_ITEMS)
 
 
 def test_update_item_create_missing_unit_name(
@@ -76,31 +95,25 @@ def test_update_item_create_missing_unit_name(
     add_error_spy.assert_called_once_with(TAB_ITEMS)
 
 
-def test_update_item_create_error(mocker, service_context, item_service, item_data_from_dict):
-    item_data_from_dict.action = ItemActionEnum.CREATE
+def test_update_item_create_error(mocker, item_create_file_data, item_service, unit_name_search):
     mocker.patch.object(
-        service_context.file_manager, "read_data", return_value=[item_data_from_dict]
+        item_create_file_data.api,
+        "post",
+        side_effect=MPTAPIError("API Error", "Error updating item"),
     )
-    mocker.patch.object(
-        service_context.api, "post", side_effect=MPTAPIError("API Error", "Error updating item")
-    )
-    search_uom_by_name_mock = mocker.patch(
-        "cli.core.products.services.item_service.search_uom_by_name",
-        return_value=Uom(id="fake_unit_id", name="User"),
-    )
-    mocker.patch.object(service_context.file_manager, "write_error")
-    mocker.spy(service_context.api, "update")
-    mocker.spy(service_context.stats, "add_error")
+    mocker.patch.object(item_create_file_data.file_manager, "write_error")
+    mocker.spy(item_create_file_data.api, "update")
+    mocker.spy(item_create_file_data.stats, "add_error")
 
     result = item_service.update()
 
     assert result.success is False
-    assert service_context.stats.tabs["Items"]["error"] == 1
-    search_uom_by_name_mock.assert_called_once()
-    service_context.api.post.assert_called_once()
-    service_context.file_manager.write_error.assert_called_once()
-    service_context.api.update.assert_not_called()
-    service_context.stats.add_error.assert_called_once_with(TAB_ITEMS)
+    assert item_create_file_data.stats.tabs["Items"]["error"] == 1
+    unit_name_search.assert_called_once()
+    item_create_file_data.api.post.assert_called_once()
+    item_create_file_data.file_manager.write_error.assert_called_once()
+    item_create_file_data.api.update.assert_not_called()
+    item_create_file_data.stats.add_error.assert_called_once_with(TAB_ITEMS)
 
 
 def test_update_item_skip(

--- a/tests/cli/core/products/services/test_product_service.py
+++ b/tests/cli/core/products/services/test_product_service.py
@@ -30,7 +30,8 @@ def product_service(service_context):
     return ProductService(service_context)
 
 
-def test_create(mocker, service_context, product_service, mpt_product_data, product_data_from_dict):
+@pytest.fixture
+def product_create_flow(mocker, service_context, mpt_product_data, product_data_from_dict):
     mocker.patch.object(
         service_context.file_manager, "read_data", return_value=product_data_from_dict
     )
@@ -38,17 +39,65 @@ def test_create(mocker, service_context, product_service, mpt_product_data, prod
     mocker.patch.object(service_context.api, "update")
     mocker.patch.object(service_context.file_manager, "write_ids")
     mocker.spy(service_context.stats, "add_synced")
+    return service_context
+
+
+@pytest.fixture
+def product_create_update_error_flow(
+    mocker, service_context, mpt_product_data, product_data_from_dict
+):
+    mocker.patch.object(
+        service_context.file_manager, "read_data", return_value=product_data_from_dict
+    )
+    mocker.patch.object(service_context.api, "post", return_value=mpt_product_data)
+    mocker.patch.object(
+        service_context.api,
+        "update",
+        side_effect=MPTAPIError("API Error", "Error creating product"),
+    )
+    mocker.patch.object(service_context.file_manager, "write_error")
+    mocker.spy(service_context.stats, "add_error")
+    return service_context
+
+
+@pytest.fixture
+def product_export_flow(mocker, service_context, mpt_product_data):
+    mocker.patch.object(service_context.api, "get", return_value=mpt_product_data)
+    mocker.patch.object(service_context.file_manager, "create_tab")
+    mocker.patch.object(service_context.file_manager, "add")
+    mocker.patch.object(SettingsExcelFileManager, "create_tab")
+    mocker.patch.object(SettingsExcelFileManager, "add")
+    return service_context
+
+
+@pytest.fixture
+def product_update_error_flow(mocker, service_context, product_data_from_dict):
+    mocker.patch.object(service_context.file_manager, "read_data", return_value=Mock(id=None))
+    mocker.patch.object(
+        SettingsExcelFileManager, "read_data", return_value=iter([product_data_from_dict.settings])
+    )
+    mocker.patch.object(
+        service_context.api,
+        "update",
+        side_effect=MPTAPIError("API Error", "Error updating product"),
+    )
+    mocker.spy(service_context.stats, "add_error")
+    mocker.patch.object(service_context.file_manager, "write_error")
+    return service_context
+
+
+def test_create(product_create_flow, product_service, product_data_from_dict):
 
     result = product_service.create()
 
     assert result.success is True
-    service_context.file_manager.read_data.assert_called_once()
-    service_context.stats.add_synced.assert_called_once_with(TAB_GENERAL)
-    service_context.file_manager.write_ids.assert_called_once_with({
+    product_create_flow.file_manager.read_data.assert_called_once()
+    product_create_flow.stats.add_synced.assert_called_once_with(TAB_GENERAL)
+    product_create_flow.file_manager.write_ids.assert_called_once_with({
         "B3": product_data_from_dict.id
     })
-    service_context.api.post.assert_called_once()
-    service_context.api.update.assert_called_once()
+    product_create_flow.api.post.assert_called_once()
+    product_create_flow.api.update.assert_called_once()
 
 
 def test_create_post_error(mocker, service_context, product_service, product_data_from_dict):
@@ -74,46 +123,28 @@ def test_create_post_error(mocker, service_context, product_service, product_dat
     file_handler_write_mock.assert_called_once()
 
 
-def test_create_update_error(
-    mocker, service_context, product_service, mpt_product_data, product_data_from_dict
-):
-    mocker.patch.object(
-        service_context.file_manager, "read_data", return_value=product_data_from_dict
-    )
-    mocker.patch.object(service_context.api, "post", return_value=mpt_product_data)
-    mocker.patch.object(
-        service_context.api,
-        "update",
-        side_effect=MPTAPIError("API Error", "Error creating product"),
-    )
-    mocker.patch.object(service_context.file_manager, "write_error")
-    mocker.spy(service_context.stats, "add_error")
+def test_create_update_error(product_create_update_error_flow, product_service):
 
     result = product_service.create()
 
     assert result.success is False
     assert result.errors == ["API Error with response body Error creating product"]
     assert result.model is None
-    service_context.stats.add_error.assert_called_once_with(TAB_GENERAL)
-    service_context.file_manager.read_data.assert_called_once()
-    service_context.api.post.assert_called_once()
-    service_context.api.update.assert_called_once()
-    service_context.file_manager.write_error.assert_called_once()
+    product_create_update_error_flow.stats.add_error.assert_called_once_with(TAB_GENERAL)
+    product_create_update_error_flow.file_manager.read_data.assert_called_once()
+    product_create_update_error_flow.api.post.assert_called_once()
+    product_create_update_error_flow.api.update.assert_called_once()
+    product_create_update_error_flow.file_manager.write_error.assert_called_once()
 
 
-def test_export(mocker, service_context, product_service, mpt_product_data):
-    mocker.patch.object(service_context.api, "get", return_value=mpt_product_data)
-    mocker.patch.object(service_context.file_manager, "create_tab")
-    mocker.patch.object(service_context.file_manager, "add")
-    mocker.patch.object(SettingsExcelFileManager, "create_tab")
-    mocker.patch.object(SettingsExcelFileManager, "add")
+def test_export(product_export_flow, product_service):
 
     result = product_service.export({"product_id": "fake_id"})
 
     assert result.success is True
-    service_context.api.get.assert_called()
-    service_context.file_manager.create_tab.assert_called_once()
-    service_context.file_manager.add.assert_called_once()
+    product_export_flow.api.get.assert_called()
+    product_export_flow.file_manager.create_tab.assert_called_once()
+    product_export_flow.file_manager.add.assert_called_once()
     SettingsExcelFileManager.create_tab.assert_called_once()
     SettingsExcelFileManager.add.assert_called_once()
 
@@ -297,26 +328,15 @@ def test_update(mocker, service_context, product_service, product_data_from_dict
     api_update_mock.assert_called_once_with(product_data_from_dict.id, expected_data)
 
 
-def test_update_error(mocker, service_context, product_service, product_data_from_dict):
-    mocker.patch.object(service_context.file_manager, "read_data", return_value=Mock(id=None))
-    mocker.patch.object(
-        SettingsExcelFileManager, "read_data", return_value=iter([product_data_from_dict.settings])
-    )
-    mocker.patch.object(
-        service_context.api,
-        "update",
-        side_effect=MPTAPIError("API Error", "Error updating product"),
-    )
-    mocker.spy(service_context.stats, "add_error")
-    mocker.patch.object(service_context.file_manager, "write_error")
+def test_update_error(product_update_error_flow, product_service):
 
     result = product_service.update()
 
     assert result.success is False
     assert result.errors == ["API Error with response body Error updating product"]
     assert result.model is None
-    service_context.file_manager.read_data.assert_called_once()
+    product_update_error_flow.file_manager.read_data.assert_called_once()
     SettingsExcelFileManager.read_data.assert_called_once()
-    service_context.stats.add_error.assert_called_once_with(TAB_GENERAL)
-    service_context.file_manager.write_error.assert_called_once()
-    service_context.api.update.assert_called_once()
+    product_update_error_flow.stats.add_error.assert_called_once_with(TAB_GENERAL)
+    product_update_error_flow.file_manager.write_error.assert_called_once()
+    product_update_error_flow.api.update.assert_called_once()

--- a/tests/cli/core/products/services/test_related_components_base_service.py
+++ b/tests/cli/core/products/services/test_related_components_base_service.py
@@ -69,6 +69,20 @@ def related_components_service(service_context):
     return FakeRelatedComponentsService(service_context)
 
 
+@pytest.fixture
+def related_components_export_error(mocker, service_context):
+    mocker.patch.object(service_context.file_manager, "create_tab")
+    mocker.patch.object(
+        service_context.api,
+        "list",
+        side_effect=MPTAPIError("API Error", "Error getting parameters"),
+    )
+    mocker.patch.object(service_context.file_manager, "write_error")
+    mocker.patch.object(service_context.stats, "add_error")
+    mocker.spy(service_context.file_manager, "add")
+    return service_context
+
+
 def test_create(mocker, service_context, related_components_service, mpt_agreement_parameter_data):
     data_model_mock = FakeDataModel()
     new_item_mock = {"id": "new_fake_id"}
@@ -129,28 +143,17 @@ def test_export(mocker, service_context, related_components_service, mpt_agreeme
     add_mock.assert_called_once()
 
 
-def test_export_error(
-    mocker, service_context, related_components_service, mpt_agreement_parameter_data
-):
-    mocker.patch.object(service_context.file_manager, "create_tab")
-    mocker.patch.object(
-        service_context.api,
-        "list",
-        side_effect=MPTAPIError("API Error", "Error getting parameters"),
-    )
-    mocker.patch.object(service_context.file_manager, "write_error")
-    mocker.patch.object(service_context.stats, "add_error")
-    mocker.spy(service_context.file_manager, "add")
+def test_export_error(related_components_export_error, related_components_service):
 
     result = related_components_service.export()
 
     assert result.success is False
     assert result.errors == ["API Error with response body Error getting parameters"]
-    service_context.file_manager.create_tab.assert_called_once()
-    service_context.api.list.assert_called_once()
-    service_context.stats.add_error.assert_called_once_with("fake_tab_name")
-    service_context.file_manager.write_error.assert_called_once()
-    service_context.file_manager.add.assert_not_called()
+    related_components_export_error.file_manager.create_tab.assert_called_once()
+    related_components_export_error.api.list.assert_called_once()
+    related_components_export_error.stats.add_error.assert_called_once_with("fake_tab_name")
+    related_components_export_error.file_manager.write_error.assert_called_once()
+    related_components_export_error.file_manager.add.assert_not_called()
 
 
 def test_update_action_skip(mocker, service_context, related_components_service):


### PR DESCRIPTION
🤖 **AI-generated PR** — Please review carefully.

## Summary
- Remove WPS213 from the test ignore list, stacked on the WPS210/WPS221 cleanup branch.
- Refactor repeated product sync and service test expressions into concrete scenario fixtures.
- Keep assertions explicit without generic helpers, including the product update flow reviewed from CodeRabbit feedback.

## Validation
- `make check`
- `docker compose run --rm app pytest tests/cli/core/products/app/test_sync.py -q`
- `docker compose run --rm app flake8 tests --per-file-ignores="" --format='%(path)s:%(row)d:%(col)d:%(code)s:%(text)s' 2>/dev/null | rg 'WPS213|WPS204|WPS210|WPS221|WPS211|WPS227'`\n\nCloses [MPT-17825](https://softwareone.atlassian.net/browse/MPT-17825)\n\n[MPT-17825]: https://softwareone.atlassian.net/browse/MPT-17825

[MPT-17825]: https://softwareone.atlassian.net/browse/MPT-17825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-17825](https://softwareone.atlassian.net/browse/MPT-17825)

- Removed WPS213 from flake8 per-file ignore configuration in `pyproject.toml`
- Introduced reusable pytest fixtures to reduce per-test mocking across product and service test modules:
  - `product_update_container` fixture in product sync tests
  - `item_data_to_create`, `unit_name_search`, `item_create_file_data`, and `item_create_update_flow` fixtures in item service tests
  - `product_create_flow`, `product_create_update_error_flow`, `product_export_flow`, and `product_update_error_flow` fixtures in product service tests
  - `related_components_export_error` fixture in related components service tests
- Refactored test functions to utilize the new fixtures while maintaining explicit assertion patterns, eliminating inline mocking setup
- Updated test function signatures to depend on the new fixtures rather than manual dependency parameters

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softwareone-platform/swo-marketplace-cli/pull/218)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->