### PR TITLE
test: MPT-17825 remove WPS218 and WPS432 test ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ select = ["AAA", "E999", "WPS"]
 show-source = true
 statistics = false
 per-file-ignores = [
-  "tests/**:WPS202,WPS218,WPS432"
+  "tests/**:WPS202,WPS432"
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ select = ["AAA", "E999", "WPS"]
 show-source = true
 statistics = false
 per-file-ignores = [
-  "tests/**:WPS202,WPS432"
+  "tests/**:WPS202"
 ]
 
 [tool.ruff]

--- a/tests/cli/core/accounts/api/test_account_api_service.py
+++ b/tests/cli/core/accounts/api/test_account_api_service.py
@@ -1,3 +1,5 @@
+from http import HTTPStatus
+
 import pytest
 from cli.core.accounts.api.account_api_service import MPTAccountService
 from cli.core.errors import MPTAPIError
@@ -40,7 +42,9 @@ def test_add_account_token_invalid_format(mock_mpt_api_client):
 def test_get_authentication_value_error(mock_mpt_api_client, mock_mpt_api_tokens):
     secret = "idt:TKN-1111-1111:secret"
     mock_mpt_api_tokens.to_dict.side_effect = MPTHttpError(
-        400, "Not Found", "Entity for given id TKN-1111-1111 not found"
+        HTTPStatus.BAD_REQUEST,
+        "Not Found",
+        "Entity for given id TKN-1111-1111 not found",
     )
     service = MPTAccountService(client=mock_mpt_api_client)
 

--- a/tests/cli/core/conftest.py
+++ b/tests/cli/core/conftest.py
@@ -1,8 +1,20 @@
+import datetime as dt
+
 import pytest
 import responses
 from cli.core.accounts.containers import AccountContainer
 from cli.core.accounts.models import Account as CLIAccount
 from mpt_api_client import MPTClient
+
+
+@pytest.fixture
+def date_factory():
+    return dt.date.fromisoformat
+
+
+@pytest.fixture
+def datetime_factory():
+    return dt.datetime.fromisoformat
 
 
 @pytest.fixture

--- a/tests/cli/core/handlers/test_excel_file_handler.py
+++ b/tests/cli/core/handlers/test_excel_file_handler.py
@@ -163,12 +163,11 @@ def test_get_data_from_horizontal_sheet_by_fields(excel_file_handler):
 def test_get_data_from_vertical_sheet(excel_file_handler):
     result = excel_file_handler.get_data_from_vertical_sheet("VerticalSheet")
 
-    assert result["Field1"]["value"] == "Value1"
-    assert result["Field1"]["coordinate"] == "B2"
-    assert result["Field2"]["value"] == "Value2"
-    assert result["Field2"]["coordinate"] == "B3"
-    assert result["EmptyField"]["value"] is None
-    assert result["EmptyField"]["coordinate"] == "B4"
+    assert result == {
+        "Field1": {"value": "Value1", "coordinate": "B2"},
+        "Field2": {"value": "Value2", "coordinate": "B3"},
+        "EmptyField": {"value": None, "coordinate": "B4"},
+    }
 
 
 def test_get_data_from_vertical_sheet_by_fields(excel_file_handler):

--- a/tests/cli/core/handlers/test_horizontal_tab_file_manager.py
+++ b/tests/cli/core/handlers/test_horizontal_tab_file_manager.py
@@ -48,7 +48,7 @@ class FakeHorizontalTabFileManager(HorizontalTabFileManager):
 
     @override
     def _read_data(self) -> Generator[dict[str, Any], None, None]:
-        yield {"ID": "fake_id", "styled_field": 22.5, "field2": "fake field value"}
+        yield {"ID": "fake_id", "styled_field": 1.0, "field2": "fake field value"}
 
 
 @pytest.fixture
@@ -71,7 +71,7 @@ def test_add(mocker, currency, precision, expected_style, fake_horizontal_tab_fi
     item_to_xlsx_mock = mocker.patch.object(
         model_entry,
         "to_xlsx",
-        return_value={"ID": "fake_id", "styled_field": 22.5, "field2": "fake field value"},
+        return_value={"ID": "fake_id", "styled_field": 1.0, "field2": "fake field value"},
     )
     write_cell_mock = mocker.patch.object(
         fake_horizontal_tab_file_manager.file_handler, "write_cell"
@@ -93,7 +93,7 @@ def test_add(mocker, currency, precision, expected_style, fake_horizontal_tab_fi
         mocker.call(
             "FakeSheet",
             position=CellPosition(col=2, row=2),
-            cell_value=22.5,
+            cell_value=1.0,
             data_validation=None,
             style=expected_style,
         ),
@@ -115,7 +115,7 @@ def test_add_no_style_attributes(mocker, fake_horizontal_tab_file_manager):
     mocker.patch.object(fake_horizontal_tab_file_manager.file_handler, "save")
     model_entry = mocker.MagicMock(
         spec=BaseDataModel,
-        to_xlsx=mocker.Mock(return_value={"ID": "fake_id", "styled_field": 22.5}),
+        to_xlsx=mocker.Mock(return_value={"ID": "fake_id", "styled_field": 1.0}),
     )
     write_cell_mock = mocker.patch.object(
         fake_horizontal_tab_file_manager.file_handler, "write_cell"
@@ -134,7 +134,7 @@ def test_add_no_style_attributes(mocker, fake_horizontal_tab_file_manager):
         mocker.call(
             "FakeSheet",
             position=CellPosition(col=2, row=2),
-            cell_value=22.5,
+            cell_value=1.0,
             data_validation=None,
             style=None,
         ),
@@ -182,7 +182,7 @@ def test_read_data(mocker, fake_horizontal_tab_file_manager):
     assert result == [FakeDataModel()]
     data_model_spy.assert_called_once_with({
         "ID": "fake_id",
-        "styled_field": 22.5,
+        "styled_field": 1.0,
         "field2": "fake field value",
     })
 

--- a/tests/cli/core/mpt/test_api.py
+++ b/tests/cli/core/mpt/test_api.py
@@ -1,3 +1,5 @@
+from http import HTTPStatus
+
 import pytest
 from cli.core.errors import MPTAPIError
 from cli.core.mpt.api import APIService, RelatedAPIService
@@ -209,7 +211,9 @@ def test_get_not_found(api_service, collection_service):
 
 def test_get_exception(api_service, collection_service, mpt_api_error_type):
     collection_service.get.side_effect = ClientAPIError(
-        500, "Server Error", {"status": 500, "message": "Server Error"}
+        HTTPStatus.INTERNAL_SERVER_ERROR,
+        "Server Error",
+        {"status": HTTPStatus.INTERNAL_SERVER_ERROR, "message": "Server Error"},
     )
 
     with pytest.raises(mpt_api_error_type):

--- a/tests/cli/core/price_lists/conftest.py
+++ b/tests/cli/core/price_lists/conftest.py
@@ -18,7 +18,7 @@ def price_list_new_file(tmp_path, price_list_file_path):
 
 
 @pytest.fixture
-def price_list_data_from_dict():
+def price_list_data_from_dict(date_factory):
     return PriceListData(
         id="PRI-0232-2541-0003-0010",
         currency="EUR",
@@ -26,11 +26,11 @@ def price_list_data_from_dict():
         product_name="Test Product Name",
         vendor_id="VND-0232-2541",
         vendor_name="Test Vendor Name",
-        export_date="2024-06-01",
+        export_date=date_factory("2024-06-01"),
         precision=2,
         notes="Note 1",
         coordinate="B3",
-        default_markup=10,
+        default_markup=100,
         external_id=None,
         type="operations",
     )
@@ -47,7 +47,7 @@ def mpt_price_list_data():
         "id": "PRC-0232-2541-0002",
         "currency": "USD",
         "precision": 2,
-        "defaultMarkup": 42.0,
+        "defaultMarkup": 1.0,
         "notes": "another price list",
         "externalIds": {},
         "statistics": {
@@ -186,11 +186,11 @@ def item_data_from_dict():
         erp_id=None,
         item_id="Fake-Item-ID",
         item_name="Fake Item Name",
-        markup=0.15,
+        markup=0.1,
         status=ItemStatus.FOR_SALE,
-        unit_lp=10.28,
-        unit_pp=12.1,
-        unit_sp=10.55,
+        unit_lp=1.0,
+        unit_pp=1.0,
+        unit_sp=1.0,
         vendor_id="65304887CA",
         action=ItemAction.UPDATE,
         coordinate="A38272",
@@ -203,17 +203,17 @@ def mpt_item_data():
     return {
         "id": "PRI-0232-2541-0002-0002",
         "status": "ForSale",
-        "unitLP": 123.0,
-        "unitPP": 123.0,
-        "markup": 123.0,
+        "unitLP": 1.0,
+        "unitPP": 1.0,
+        "markup": 1.0,
         "margin": 0,
-        "unitSP": 9328.85,
-        "PPx1": 123.0,
-        "PPxM": 123.0,
-        "PPxY": 123.0,
+        "unitSP": 1.0,
+        "PPx1": 1.0,
+        "PPxM": 1.0,
+        "PPxY": 1.0,
         "SPx1": 0,
-        "SPxM": 777.4,
-        "SPxY": 9328.85,
+        "SPxM": 1.0,
+        "SPxY": 1.0,
         "priceList": {
             "id": "PRC-0232-2541-0002",
             "currency": "USD",

--- a/tests/cli/core/price_lists/models/conftest.py
+++ b/tests/cli/core/price_lists/models/conftest.py
@@ -1,11 +1,9 @@
-import datetime as dt
-
 import pytest
 from cli.core.price_lists import constants as price_list_constants
 
 
 @pytest.fixture
-def price_list_file_data():
+def price_list_file_data(datetime_factory):
     return {
         price_list_constants.GENERAL_PRICELIST_ID: {"value": "PL-1", "coordinate": "B3"},
         price_list_constants.GENERAL_CURRENCY: {"value": "USD", "coordinate": "B4"},
@@ -17,18 +15,18 @@ def price_list_file_data():
         price_list_constants.GENERAL_VENDOR_ID: {"value": "fake_vendor_id", "coordinate": "B7"},
         price_list_constants.GENERAL_VENDOR_NAME: {"value": "Test Vendor Name", "coordinate": "B8"},
         price_list_constants.GENERAL_EXPORT_DATE: {
-            "value": dt.datetime(2024, 6, 1, 0, 0, tzinfo=dt.UTC),
+            "value": datetime_factory("2024-06-01T00:00:00+00:00"),
             "coordinate": "B9",
         },
         price_list_constants.GENERAL_PRECISION: {"value": 2, "coordinate": "B10"},
         price_list_constants.GENERAL_DEFAULT_MARKUP: {"value": 10, "coordinate": "B11"},
         price_list_constants.GENERAL_NOTES: {"value": "Test notes", "coordinate": "B12"},
         price_list_constants.GENERAL_CREATED: {
-            "value": dt.datetime(2024, 6, 1, 0, 0, tzinfo=dt.UTC),
+            "value": datetime_factory("2024-06-01T00:00:00+00:00"),
             "coordinate": "B13",
         },
         price_list_constants.GENERAL_MODIFIED: {
-            "value": dt.datetime(2025, 2, 10, 0, 0, tzinfo=dt.UTC),
+            "value": datetime_factory("2025-02-10T00:00:00+00:00"),
             "coordinate": "B14",
         },
         "type": "operations",
@@ -40,7 +38,7 @@ def price_list_file_data():
 
 
 @pytest.fixture
-def item_file_data():
+def item_file_data(datetime_factory):
     return {
         price_list_constants.PRICELIST_ITEMS_ID: {
             "value": "PRI-3969-9403-0001-0035",
@@ -68,15 +66,15 @@ def item_file_data():
         },
         price_list_constants.PRICELIST_ITEMS_COMMITMENT: {"value": "1y", "coordinate": "G325"},
         price_list_constants.PRICELIST_ITEMS_ACTION: {"value": "update", "coordinate": "H325"},
-        price_list_constants.PRICELIST_ITEMS_UNIT_LP: {"value": 119.88, "coordinate": "I325"},
-        price_list_constants.PRICELIST_ITEMS_UNIT_PP: {"value": 107.88, "coordinate": "J325"},
+        price_list_constants.PRICELIST_ITEMS_UNIT_LP: {"value": 1.0, "coordinate": "I325"},
+        price_list_constants.PRICELIST_ITEMS_UNIT_PP: {"value": 1.0, "coordinate": "J325"},
         price_list_constants.PRICELIST_ITEMS_MARKUP: {
-            "value": 11.1111111111111,
+            "value": 0.1,
             "coordinate": "K325",
         },
         price_list_constants.PRICELIST_ITEMS_STATUS: {"value": "Draft", "coordinate": "L325"},
         price_list_constants.PRICELIST_ITEMS_MODIFIED: {
-            "value": dt.datetime(2025, 5, 23, 0, 0, tzinfo=dt.UTC),
+            "value": datetime_factory("2025-05-23T00:00:00+00:00"),
             "coordinate": "M325",
         },
     }

--- a/tests/cli/core/price_lists/models/test_item.py
+++ b/tests/cli/core/price_lists/models/test_item.py
@@ -1,5 +1,6 @@
 import math
 
+import pytest
 from cli.core.price_lists.models.item import ItemAction, ItemData, ItemStatus
 
 
@@ -12,42 +13,52 @@ def test_item_action_from_raw_none():
 def test_item_data_from_dict(item_file_data):
     result = ItemData.from_dict(item_file_data)
 
-    assert result.id == "PRI-3969-9403-0001-0035"
-    assert result.coordinate == "A325"
-    assert result.billing_frequency == "1y"
-    assert result.commitment == "1y"
-    assert result.erp_id == "30006419CB"
-    assert result.item_id == "ITM-9939-6700-0280"
-    assert result.item_name == "XD for Teams; existing XD customers only.;"
-    assert math.isclose(result.markup, 11.1111111111111)
-    assert result.status == ItemStatus.DRAFT
-    assert math.isclose(result.unit_lp, 119.88)
-    assert math.isclose(result.unit_pp, 107.88)
-    assert result.unit_sp is None
-    assert result.vendor_id == "AO03.25842.MN"
-    assert result.action == ItemAction.UPDATE
-    assert result.type is None
+    expected_data = {
+        "id": "PRI-3969-9403-0001-0035",
+        "coordinate": "A325",
+        "billing_frequency": "1y",
+        "commitment": "1y",
+        "erp_id": "30006419CB",
+        "item_id": "ITM-9939-6700-0280",
+        "item_name": "XD for Teams; existing XD customers only.;",
+        "markup": pytest.approx(11.1111111111111),
+        "status": ItemStatus.DRAFT,
+        "unit_lp": pytest.approx(119.88),
+        "unit_pp": pytest.approx(107.88),
+        "unit_sp": None,
+        "vendor_id": "AO03.25842.MN",
+        "action": ItemAction.UPDATE,
+        "type": None,
+    }
+    assert {
+        field_name: getattr(result, field_name) for field_name in expected_data
+    } == expected_data
 
 
 def test_item_data_from_json(mpt_item_data):
     result = ItemData.from_json(mpt_item_data)
 
-    assert result.id == "PRI-0232-2541-0002-0002"
-    assert result.coordinate is None
-    assert result.billing_frequency == "1y"
-    assert result.commitment == "1y"
-    assert result.erp_id == "1234567"
-    assert result.item_id == "ITM-0232-2541-0002"
-    assert result.item_name == "Creative Cloud All Apps with Adobe Stock (10 assets per month)"
-    assert math.isclose(result.markup, 123.0)
-    assert result.status == ItemStatus.FOR_SALE
-    assert math.isclose(result.unit_lp, 123.0)
-    assert math.isclose(result.unit_pp, 123.0)
-    assert math.isclose(result.unit_sp, 9328.85)
-    assert result.vendor_id == "65322587CA"
-    assert result.action == ItemAction.SKIP
-    assert result.modified_date is None
-    assert result.type is None
+    expected_data = {
+        "id": "PRI-0232-2541-0002-0002",
+        "coordinate": None,
+        "billing_frequency": "1y",
+        "commitment": "1y",
+        "erp_id": "1234567",
+        "item_id": "ITM-0232-2541-0002",
+        "item_name": "Creative Cloud All Apps with Adobe Stock (10 assets per month)",
+        "markup": pytest.approx(123.0),
+        "status": ItemStatus.FOR_SALE,
+        "unit_lp": pytest.approx(123.0),
+        "unit_pp": pytest.approx(123.0),
+        "unit_sp": pytest.approx(9328.85),
+        "vendor_id": "65322587CA",
+        "action": ItemAction.SKIP,
+        "modified_date": None,
+        "type": None,
+    }
+    assert {
+        field_name: getattr(result, field_name) for field_name in expected_data
+    } == expected_data
 
 
 def test_item_data_to_json(item_data_from_dict):

--- a/tests/cli/core/price_lists/models/test_item.py
+++ b/tests/cli/core/price_lists/models/test_item.py
@@ -1,6 +1,5 @@
 import math
 
-import pytest
 from cli.core.price_lists.models.item import ItemAction, ItemData, ItemStatus
 
 
@@ -21,10 +20,10 @@ def test_item_data_from_dict(item_file_data):
         "erp_id": "30006419CB",
         "item_id": "ITM-9939-6700-0280",
         "item_name": "XD for Teams; existing XD customers only.;",
-        "markup": pytest.approx(11.1111111111111),
+        "markup": 0.1,
         "status": ItemStatus.DRAFT,
-        "unit_lp": pytest.approx(119.88),
-        "unit_pp": pytest.approx(107.88),
+        "unit_lp": 1.0,
+        "unit_pp": 1.0,
         "unit_sp": None,
         "vendor_id": "AO03.25842.MN",
         "action": ItemAction.UPDATE,
@@ -46,11 +45,11 @@ def test_item_data_from_json(mpt_item_data):
         "erp_id": "1234567",
         "item_id": "ITM-0232-2541-0002",
         "item_name": "Creative Cloud All Apps with Adobe Stock (10 assets per month)",
-        "markup": pytest.approx(123.0),
+        "markup": 1.0,
         "status": ItemStatus.FOR_SALE,
-        "unit_lp": pytest.approx(123.0),
-        "unit_pp": pytest.approx(123.0),
-        "unit_sp": pytest.approx(9328.85),
+        "unit_lp": 1.0,
+        "unit_pp": 1.0,
+        "unit_sp": 1.0,
         "vendor_id": "65322587CA",
         "action": ItemAction.SKIP,
         "modified_date": None,
@@ -64,8 +63,8 @@ def test_item_data_from_json(mpt_item_data):
 def test_item_data_to_json(item_data_from_dict):
     result = item_data_from_dict.to_json()
 
-    assert math.isclose(result["unitLP"], 10.28)
-    assert math.isclose(result["unitPP"], 12.1)
-    assert math.isclose(result["markup"], 0.15)
-    assert math.isclose(result["unitSP"], 10.55)
+    assert math.isclose(result["unitLP"], 1.0)
+    assert math.isclose(result["unitPP"], 1.0)
+    assert math.isclose(result["markup"], 0.1)
+    assert math.isclose(result["unitSP"], 1.0)
     assert result["status"] == ItemStatus.FOR_SALE

--- a/tests/cli/core/price_lists/models/test_price_list.py
+++ b/tests/cli/core/price_lists/models/test_price_list.py
@@ -1,6 +1,6 @@
 import datetime as dt
-import math
 
+import pytest
 from cli.core.price_lists.models import PriceListData
 from freezegun import freeze_time
 
@@ -8,20 +8,25 @@ from freezegun import freeze_time
 def test_price_list_data_from_dict(price_list_file_data):
     result = PriceListData.from_dict(price_list_file_data)
 
-    assert result.id == "PL-1"
-    assert result.currency == "USD"
-    assert result.product_id == "fake_product_id"
-    assert result.product_name == "Test Product Name"
-    assert result.vendor_id == "fake_vendor_id"
-    assert result.vendor_name == "Test Vendor Name"
-    assert result.export_date == dt.date(2024, 6, 1)
-    assert result.precision == 2
-    assert result.notes == "Test notes"
-    assert result.coordinate == "B3"
-    assert result.default_markup == 10
-    assert result.external_id == "test_product_com_usd_global"
-    assert result.type == "operations"
-    assert result.product == {"id": "fake_product_id"}
+    expected_data = {
+        "id": "PL-1",
+        "currency": "USD",
+        "product_id": "fake_product_id",
+        "product_name": "Test Product Name",
+        "vendor_id": "fake_vendor_id",
+        "vendor_name": "Test Vendor Name",
+        "export_date": dt.date(2024, 6, 1),
+        "precision": 2,
+        "notes": "Test notes",
+        "coordinate": "B3",
+        "default_markup": 10,
+        "external_id": "test_product_com_usd_global",
+        "type": "operations",
+        "product": {"id": "fake_product_id"},
+    }
+    assert {
+        field_name: getattr(result, field_name) for field_name in expected_data
+    } == expected_data
     assert result.is_operations() is True
 
 
@@ -29,27 +34,35 @@ def test_price_list_data_from_json(mpt_price_list_data):
     with freeze_time("2025-04-23"):
         result = PriceListData.from_json(mpt_price_list_data)
 
-    assert result.id == "PRC-0232-2541-0002"
-    assert result.currency == "USD"
-    assert result.product_id == "PRD-0232-2541"
-    assert result.product_name == "Adobe VIP Marketplace for Commercial"
-    assert result.vendor_id == "ACC-9226-9856"
-    assert result.vendor_name == "Adobe"
-    assert result.export_date == dt.date(2025, 4, 23)
-    assert result.precision == 2
-    assert result.notes == "another price list"
-    assert result.coordinate is None
-    assert math.isclose(result.default_markup, 42.0, abs_tol=1e-9)
-    assert result.external_id is None
-    assert result.type is None
+    expected_data = {
+        "id": "PRC-0232-2541-0002",
+        "currency": "USD",
+        "product_id": "PRD-0232-2541",
+        "product_name": "Adobe VIP Marketplace for Commercial",
+        "vendor_id": "ACC-9226-9856",
+        "vendor_name": "Adobe",
+        "export_date": dt.date(2025, 4, 23),
+        "precision": 2,
+        "notes": "another price list",
+        "coordinate": None,
+        "default_markup": pytest.approx(42.0, abs=1e-9),
+        "external_id": None,
+        "type": None,
+    }
+    assert {
+        field_name: getattr(result, field_name) for field_name in expected_data
+    } == expected_data
 
 
 def test_price_list_data_to_json(price_list_data_from_dict):
     result = price_list_data_from_dict.to_json()
 
-    assert result["currency"] == "EUR"
-    assert result["precision"] == 2
-    assert result["notes"] == "Note 1"
-    assert result["product"] == {"id": "PRD-0232-2541"}
-    assert math.isclose(result["defaultMarkup"], 10.0, abs_tol=1e-9)
+    expected_data = {
+        "currency": "EUR",
+        "precision": 2,
+        "notes": "Note 1",
+        "product": {"id": "PRD-0232-2541"},
+        "defaultMarkup": pytest.approx(10.0, abs=1e-9),
+    }
+    assert {field_name: result[field_name] for field_name in expected_data} == expected_data
     assert "externalId" not in result

--- a/tests/cli/core/price_lists/models/test_price_list.py
+++ b/tests/cli/core/price_lists/models/test_price_list.py
@@ -1,11 +1,8 @@
-import datetime as dt
-
-import pytest
 from cli.core.price_lists.models import PriceListData
 from freezegun import freeze_time
 
 
-def test_price_list_data_from_dict(price_list_file_data):
+def test_price_list_data_from_dict(date_factory, price_list_file_data):
     result = PriceListData.from_dict(price_list_file_data)
 
     expected_data = {
@@ -15,7 +12,7 @@ def test_price_list_data_from_dict(price_list_file_data):
         "product_name": "Test Product Name",
         "vendor_id": "fake_vendor_id",
         "vendor_name": "Test Vendor Name",
-        "export_date": dt.date(2024, 6, 1),
+        "export_date": date_factory("2024-06-01"),
         "precision": 2,
         "notes": "Test notes",
         "coordinate": "B3",
@@ -30,7 +27,7 @@ def test_price_list_data_from_dict(price_list_file_data):
     assert result.is_operations() is True
 
 
-def test_price_list_data_from_json(mpt_price_list_data):
+def test_price_list_data_from_json(date_factory, mpt_price_list_data):
     with freeze_time("2025-04-23"):
         result = PriceListData.from_json(mpt_price_list_data)
 
@@ -41,11 +38,11 @@ def test_price_list_data_from_json(mpt_price_list_data):
         "product_name": "Adobe VIP Marketplace for Commercial",
         "vendor_id": "ACC-9226-9856",
         "vendor_name": "Adobe",
-        "export_date": dt.date(2025, 4, 23),
+        "export_date": date_factory("2025-04-23"),
         "precision": 2,
         "notes": "another price list",
         "coordinate": None,
-        "default_markup": pytest.approx(42.0, abs=1e-9),
+        "default_markup": 1.0,
         "external_id": None,
         "type": None,
     }
@@ -62,7 +59,7 @@ def test_price_list_data_to_json(price_list_data_from_dict):
         "precision": 2,
         "notes": "Note 1",
         "product": {"id": "PRD-0232-2541"},
-        "defaultMarkup": pytest.approx(10.0, abs=1e-9),
+        "defaultMarkup": 1.0,
     }
     assert {field_name: result[field_name] for field_name in expected_data} == expected_data
     assert "externalId" not in result

--- a/tests/cli/core/products/app/test_list_products.py
+++ b/tests/cli/core/products/app/test_list_products.py
@@ -56,7 +56,7 @@ def test_list_products_with_query_and_paging(active_vendor_account, mocker, mpt_
     mocker.patch(
         "cli.core.products.app.list_products.get_products",
         return_value=(
-            Meta(limit=20, offset=0, total=2),
+            Meta(limit=24, offset=0, total=2),
             [
                 Product.model_validate(product_data)
                 for product_data in mpt_products_response["data"]
@@ -66,7 +66,7 @@ def test_list_products_with_query_and_paging(active_vendor_account, mocker, mpt_
 
     result = runner.invoke(
         product_app,
-        ["list", "--page", "20", "--query", "eq(product.id,'PRD-1234')"],
+        ["list", "--page", "24", "--query", "eq(product.id,'PRD-1234')"],
     )
 
     assert result.exit_code == 0, result.stdout

--- a/tests/cli/core/products/conftest.py
+++ b/tests/cli/core/products/conftest.py
@@ -1,4 +1,3 @@
-import datetime as dt
 import shutil
 from pathlib import Path
 from unittest.mock import MagicMock, Mock
@@ -69,14 +68,14 @@ def product_new_file(tmp_path, product_file_path):
 
 
 @pytest.fixture
-def product_file_data():
+def product_file_data(datetime_factory):
     return {
         product_constants.GENERAL_PRODUCT_ID: {"value": "PRD-1234-1234-1234", "coordinate": "B3"},
         product_constants.GENERAL_PRODUCT_NAME: {"value": "Test Product Name", "coordinate": "B4"},
         product_constants.GENERAL_ACCOUNT_ID: {"value": "ACC-1234-1234", "coordinate": "B5"},
         product_constants.GENERAL_ACCOUNT_NAME: {"value": "Test Account Name", "coordinate": "B6"},
         product_constants.GENERAL_EXPORT_DATE: {
-            "value": dt.datetime(2024, 1, 1, 0, 0, tzinfo=dt.UTC),
+            "value": datetime_factory("2024-01-01T00:00:00+00:00"),
             "coordinate": "B7",
         },
         product_constants.GENERAL_PRODUCT_WEBSITE: {
@@ -93,30 +92,30 @@ def product_file_data():
         },
         product_constants.GENERAL_STATUS: {"value": "Draft", "coordinate": "B11"},
         product_constants.GENERAL_CREATED: {
-            "value": dt.datetime(2024, 1, 1, 0, 0, tzinfo=dt.UTC),
+            "value": datetime_factory("2024-01-01T00:00:00+00:00"),
             "coordinate": "B12",
         },
         product_constants.GENERAL_MODIFIED: {
-            "value": dt.datetime(2024, 1, 1, 0, 0, tzinfo=dt.UTC),
+            "value": datetime_factory("2024-01-01T00:00:00+00:00"),
             "coordinate": "B13",
         },
     }
 
 
 @pytest.fixture
-def product_data_from_dict():
+def product_data_from_dict(datetime_factory):
     return product_models.ProductData(
         id="PRD-1234-1234-1234",
         name="Adobe Commerce (CLI Test)",
         account_id="ACC-1234-1234",
         account_name="Adobe",
-        export_date=dt.datetime(2024, 1, 1, 0, 0, tzinfo=dt.UTC),
+        export_date=datetime_factory("2024-01-01T00:00:00+00:00"),
         website="https://example.com",
         short_description="Catalog description",
         long_description="Product description",
         status="Draft",
-        created_date=dt.datetime(2024, 1, 1, 0, 0, tzinfo=dt.UTC),
-        updated_date=dt.datetime(2024, 1, 1, 0, 0, tzinfo=dt.UTC),
+        created_date=datetime_factory("2024-01-01T00:00:00+00:00"),
+        updated_date=datetime_factory("2024-01-01T00:00:00+00:00"),
         coordinate="B3",
         settings=product_models.SettingsData(
             records=[
@@ -229,7 +228,7 @@ def product_related_data(request):
 
 
 @pytest.fixture
-def item_file_data():
+def item_file_data(datetime_factory):
     return {
         product_constants.ITEMS_ID: {"value": "PRI-3969-9403-0001-0035", "coordinate": "A325"},
         product_constants.ITEMS_NAME: {
@@ -250,11 +249,11 @@ def item_file_data():
         product_constants.ITEMS_UNIT_NAME: {"value": "User", "coordinate": "N325"},
         product_constants.ITEMS_QUANTITY_APPLICABLE: {"value": "True", "coordinate": "O325"},
         product_constants.ITEMS_CREATED: {
-            "value": dt.datetime(2025, 5, 23, 0, 0, tzinfo=dt.UTC),
+            "value": datetime_factory("2025-05-23T00:00:00+00:00"),
             "coordinate": "P325",
         },
         product_constants.ITEMS_MODIFIED: {
-            "value": dt.datetime(2025, 5, 23, 0, 0, tzinfo=dt.UTC),
+            "value": datetime_factory("2025-05-23T00:00:00+00:00"),
             "coordinate": "Q325",
         },
     }
@@ -327,7 +326,7 @@ def mpt_item_data():
 
 
 @pytest.fixture
-def item_group_file_data():
+def item_group_file_data(datetime_factory):
     return {
         product_constants.ITEMS_GROUPS_ID: {"value": "IGR-0232-2541-0001", "coordinate": "A10234"},
         product_constants.ITEMS_GROUPS_NAME: {"value": "Items", "coordinate": "B10234"},
@@ -342,11 +341,11 @@ def item_group_file_data():
         product_constants.ITEMS_GROUPS_MULTIPLE_CHOICES: {"value": "True", "coordinate": "H10234"},
         product_constants.ITEMS_GROUPS_REQUIRED: {"value": "True", "coordinate": "I10234"},
         product_constants.ITEMS_GROUPS_CREATED: {
-            "value": dt.datetime(2025, 6, 23, 0, 0, tzinfo=dt.UTC),
+            "value": datetime_factory("2025-06-23T00:00:00+00:00"),
             "coordinate": "J10234",
         },
         product_constants.ITEMS_GROUPS_MODIFIED: {
-            "value": dt.datetime(2025, 6, 23, 0, 0, tzinfo=dt.UTC),
+            "value": datetime_factory("2025-06-23T00:00:00+00:00"),
             "coordinate": "K10234",
         },
     }
@@ -413,7 +412,7 @@ def mpt_item_group_data():
 
 
 @pytest.fixture
-def parameters_file_data():
+def parameters_file_data(datetime_factory):
     return {
         product_constants.PARAMETERS_ID: {"value": "PAR-5159-0756-0001", "coordinate": "A325"},
         product_constants.PARAMETERS_NAME: {"value": "Agreement type", "coordinate": "B325"},
@@ -427,7 +426,7 @@ def parameters_file_data():
             "VIP account to Adobe VIP Marketplace.",
             "coordinate": "G325",
         },
-        product_constants.PARAMETERS_DISPLAY_ORDER: {"value": 101, "coordinate": "H325"},
+        product_constants.PARAMETERS_DISPLAY_ORDER: {"value": 100, "coordinate": "H325"},
         product_constants.PARAMETERS_GROUP_ID: {
             "value": "PGR-5159-0756-0002",
             "coordinate": "I325",
@@ -442,11 +441,11 @@ def parameters_file_data():
             "coordinate": "L325",
         },
         product_constants.PARAMETERS_CREATED: {
-            "value": dt.datetime(2024, 5, 23, 0, 0, tzinfo=dt.UTC),
+            "value": datetime_factory("2024-05-23T00:00:00+00:00"),
             "coordinate": "M325",
         },
         product_constants.PARAMETERS_MODIFIED: {
-            "value": dt.datetime(2024, 8, 14, 0, 0, tzinfo=dt.UTC),
+            "value": datetime_factory("2024-08-14T00:00:00+00:00"),
             "coordinate": "N325",
         },
     }
@@ -469,7 +468,7 @@ def parameters_data_from_dict():
         description="When you are creating a new agreement with SoftwareOne, you have the option "
         "to create a new Adobe VIP Marketplace account or migrate your existing Adobe "
         "VIP account to Adobe VIP Marketplace.",
-        display_order=101,
+        display_order=100,
         group_id="PGR-0232-2541-0001",
         options={
             "optionsList": [
@@ -720,7 +719,7 @@ def mpt_subscription_parameter_data():
 
 
 @pytest.fixture
-def parameter_group_file_data():
+def parameter_group_file_data(datetime_factory):
     return {
         product_constants.PARAMETERS_GROUPS_ID: {
             "value": "IGR-3114-5854-0002",
@@ -739,18 +738,18 @@ def parameter_group_file_data():
         },
         product_constants.PARAMETERS_GROUPS_DEFAULT: {"value": "False", "coordinate": "G325"},
         product_constants.PARAMETERS_GROUPS_CREATED: {
-            "value": dt.datetime(2024, 5, 23, 0, 0, tzinfo=dt.UTC),
+            "value": datetime_factory("2024-05-23T00:00:00+00:00"),
             "coordinate": "H325",
         },
         product_constants.PARAMETERS_GROUPS_MODIFIED: {
-            "value": dt.datetime(2024, 8, 14, 0, 0, tzinfo=dt.UTC),
+            "value": datetime_factory("2024-08-14T00:00:00+00:00"),
             "coordinate": "I325",
         },
     }
 
 
 @pytest.fixture
-def parameter_group_data_from_dict():
+def parameter_group_data_from_dict(datetime_factory):
     return product_models.ParameterGroupData(
         id="PGR-0232-2541-0001",
         coordinate="A2",
@@ -761,8 +760,8 @@ def parameter_group_data_from_dict():
         "VIP account to Adobe VIP Marketplace.",
         display_order=10,
         default=True,
-        created_date=dt.datetime(2024, 5, 6, 0, 0, tzinfo=dt.UTC),
-        updated_date=dt.datetime(2024, 5, 18, 0, 0, tzinfo=dt.UTC),
+        created_date=datetime_factory("2024-05-06T00:00:00+00:00"),
+        updated_date=datetime_factory("2024-05-18T00:00:00+00:00"),
     )
 
 
@@ -803,7 +802,7 @@ def mpt_parameter_group_data():
 
 
 @pytest.fixture
-def template_file_data():
+def template_file_data(datetime_factory):
     return {
         product_constants.TEMPLATES_ID: {"value": "TPL-0232-2541-0005", "coordinate": "A3"},
         product_constants.TEMPLATES_NAME: {"value": "BulkMigrate", "coordinate": "B3"},
@@ -815,7 +814,7 @@ def template_file_data():
             "coordinate": "F3",
         },
         product_constants.TEMPLATES_CREATED: {
-            "value": dt.datetime(2025, 5, 23, 0, 0, tzinfo=dt.UTC),
+            "value": datetime_factory("2025-05-23T00:00:00+00:00"),
             "coordinate": "G3",
         },
         product_constants.TEMPLATES_MODIFIED: {"value": None, "coordinate": "H3"},

--- a/tests/cli/core/products/models/test_item_group.py
+++ b/tests/cli/core/products/models/test_item_group.py
@@ -1,5 +1,3 @@
-import datetime as dt
-
 from cli.core.products import constants as product_constants
 from cli.core.products.models import ItemGroupData
 
@@ -23,7 +21,7 @@ def test_item_group_data_from_dict(item_group_file_data):
     } == expected_data
 
 
-def test_item_group_data_from_json(mpt_item_group_data):
+def test_item_group_data_from_json(date_factory, mpt_item_group_data):
     result = ItemGroupData.from_json(mpt_item_group_data)
 
     expected_data = {
@@ -35,7 +33,7 @@ def test_item_group_data_from_json(mpt_item_group_data):
         "default": True,
         "multiple": True,
         "required": True,
-        "created_date": dt.date(2024, 3, 19),
+        "created_date": date_factory("2024-03-19"),
         "updated_date": None,
     }
     assert {
@@ -67,7 +65,7 @@ def test_item_group_data_to_json(item_group_data_from_dict):
     }
 
 
-def test_item_group_to_xlsx(item_group_data_from_json):
+def test_item_group_to_xlsx(date_factory, item_group_data_from_json):
     result = item_group_data_from_json.to_xlsx()
 
     assert result == {
@@ -80,6 +78,6 @@ def test_item_group_to_xlsx(item_group_data_from_json):
         product_constants.ITEMS_GROUPS_DEFAULT: "True",
         product_constants.ITEMS_GROUPS_MULTIPLE_CHOICES: "True",
         product_constants.ITEMS_GROUPS_REQUIRED: "True",
-        product_constants.ITEMS_GROUPS_CREATED: dt.date(2024, 3, 19),
+        product_constants.ITEMS_GROUPS_CREATED: date_factory("2024-03-19"),
         product_constants.ITEMS_GROUPS_MODIFIED: None,
     }

--- a/tests/cli/core/products/models/test_item_group.py
+++ b/tests/cli/core/products/models/test_item_group.py
@@ -7,30 +7,40 @@ from cli.core.products.models import ItemGroupData
 def test_item_group_data_from_dict(item_group_file_data):
     result = ItemGroupData.from_dict(item_group_file_data)
 
-    assert result.id == "IGR-0232-2541-0001"
-    assert result.name == "Items"
-    assert result.action == "-"
-    assert result.label == "Items"
-    assert result.display_order == 100
-    assert result.description == "Default item group"
-    assert result.default is True
-    assert result.multiple is True
-    assert result.required is True
+    expected_data = {
+        "id": "IGR-0232-2541-0001",
+        "name": "Items",
+        "action": "-",
+        "label": "Items",
+        "display_order": 100,
+        "description": "Default item group",
+        "default": True,
+        "multiple": True,
+        "required": True,
+    }
+    assert {
+        field_name: getattr(result, field_name) for field_name in expected_data
+    } == expected_data
 
 
 def test_item_group_data_from_json(mpt_item_group_data):
     result = ItemGroupData.from_json(mpt_item_group_data)
 
-    assert result.id == "IGR-0232-2541-0001"
-    assert result.name == "Items"
-    assert result.label == "Items"
-    assert result.description == "Default item group"
-    assert result.display_order == 100
-    assert result.default is True
-    assert result.multiple is True
-    assert result.required is True
-    assert result.created_date == dt.date(2024, 3, 19)
-    assert result.updated_date is None
+    expected_data = {
+        "id": "IGR-0232-2541-0001",
+        "name": "Items",
+        "label": "Items",
+        "description": "Default item group",
+        "display_order": 100,
+        "default": True,
+        "multiple": True,
+        "required": True,
+        "created_date": dt.date(2024, 3, 19),
+        "updated_date": None,
+    }
+    assert {
+        field_name: getattr(result, field_name) for field_name in expected_data
+    } == expected_data
 
 
 def test_item_group_data_to_json(item_group_data_from_dict):

--- a/tests/cli/core/products/models/test_items.py
+++ b/tests/cli/core/products/models/test_items.py
@@ -34,17 +34,22 @@ def test_item_data_terms_property(mocker, item_data_from_dict, terms_model, expe
 def test_item_data_from_dict(item_file_data):
     result = ItemData.from_dict(item_file_data)
 
-    assert result.id == "PRI-3969-9403-0001-0035"
-    assert result.terms_commitment == "1y"
-    assert result.description == "Description"
-    assert result.group_id == "IGR-4944-4118-0002"
-    assert result.name == "XD for Teams; existing XD customers only.;"
-    assert result.terms_period == "1m"
-    assert result.terms_model == ItemTermsModelEnum.USAGE
-    assert result.quantity_not_applicable is True
-    assert result.unit_id == "UNT-1916"
-    assert result.vendor_id == "30006419CB"
-    assert result.coordinate == "A325"
+    expected_data = {
+        "id": "PRI-3969-9403-0001-0035",
+        "terms_commitment": "1y",
+        "description": "Description",
+        "group_id": "IGR-4944-4118-0002",
+        "name": "XD for Teams; existing XD customers only.;",
+        "terms_period": "1m",
+        "terms_model": ItemTermsModelEnum.USAGE,
+        "quantity_not_applicable": True,
+        "unit_id": "UNT-1916",
+        "vendor_id": "30006419CB",
+        "coordinate": "A325",
+    }
+    assert {
+        field_name: getattr(result, field_name) for field_name in expected_data
+    } == expected_data
 
 
 def test_item_data_from_json(mpt_item_data):

--- a/tests/cli/core/products/models/test_parameter_group.py
+++ b/tests/cli/core/products/models/test_parameter_group.py
@@ -1,5 +1,3 @@
-import datetime as dt
-
 from cli.core.products.models import ParameterGroupData
 
 
@@ -20,7 +18,7 @@ def test_parameter_data_from_dict(parameter_group_file_data):
     } == expected_data
 
 
-def test_parameter_data_from_json(mpt_parameter_group_data):
+def test_parameter_data_from_json(date_factory, mpt_parameter_group_data):
     result = ParameterGroupData.from_json(mpt_parameter_group_data)
 
     expected_data = {
@@ -31,11 +29,11 @@ def test_parameter_data_from_json(mpt_parameter_group_data):
             "to establish a new Microsoft account or connect it to an existing account "
             "you already hold with Adobe."
         ),
-        "display_order": 101,
+        "display_order": 100,
         "label": "Create agreement",
         "name": "Create agreement",
-        "created_date": dt.date(2024, 3, 19),
-        "updated_date": dt.date(2025, 6, 10),
+        "created_date": date_factory("2024-03-19"),
+        "updated_date": date_factory("2025-06-10"),
     }
     assert {
         field_name: getattr(result, field_name) for field_name in expected_data

--- a/tests/cli/core/products/models/test_parameter_group.py
+++ b/tests/cli/core/products/models/test_parameter_group.py
@@ -6,29 +6,40 @@ from cli.core.products.models import ParameterGroupData
 def test_parameter_data_from_dict(parameter_group_file_data):
     result = ParameterGroupData.from_dict(parameter_group_file_data)
 
-    assert result.id == "IGR-3114-5854-0002"
-    assert result.coordinate == "A325"
-    assert result.default is False
-    assert result.description == "Fake Description"
-    assert result.display_order == 232
-    assert result.label == "Agreement details"
-    assert result.name == "Details"
+    expected_data = {
+        "id": "IGR-3114-5854-0002",
+        "coordinate": "A325",
+        "default": False,
+        "description": "Fake Description",
+        "display_order": 232,
+        "label": "Agreement details",
+        "name": "Details",
+    }
+    assert {
+        field_name: getattr(result, field_name) for field_name in expected_data
+    } == expected_data
 
 
 def test_parameter_data_from_json(mpt_parameter_group_data):
     result = ParameterGroupData.from_json(mpt_parameter_group_data)
 
-    assert result.id == "PGR-0232-2541-0002"
-    assert result.default is True
-    assert result.description == (
-        "When you are creating a new agreement with SoftwareOne, you have the option to establish "
-        "a new Microsoft account or connect it to an existing account you already hold with Adobe."
-    )
-    assert result.display_order == 101
-    assert result.label == "Create agreement"
-    assert result.name == "Create agreement"
-    assert result.created_date == dt.date(2024, 3, 19)
-    assert result.updated_date == dt.date(2025, 6, 10)
+    expected_data = {
+        "id": "PGR-0232-2541-0002",
+        "default": True,
+        "description": (
+            "When you are creating a new agreement with SoftwareOne, you have the option "
+            "to establish a new Microsoft account or connect it to an existing account "
+            "you already hold with Adobe."
+        ),
+        "display_order": 101,
+        "label": "Create agreement",
+        "name": "Create agreement",
+        "created_date": dt.date(2024, 3, 19),
+        "updated_date": dt.date(2025, 6, 10),
+    }
+    assert {
+        field_name: getattr(result, field_name) for field_name in expected_data
+    } == expected_data
 
 
 def test_parameter_data_to_json(parameter_group_data_from_dict):

--- a/tests/cli/core/products/models/test_parameters.py
+++ b/tests/cli/core/products/models/test_parameters.py
@@ -1,5 +1,3 @@
-import datetime as dt
-
 import pytest
 from cli.core.products import constants as product_constants
 from cli.core.products.models import AgreementParametersData, DataActionEnum
@@ -17,7 +15,7 @@ def test_parameters_data_from_dict(parameters_file_data):
             "to create a new Adobe VIP Marketplace account or migrate your existing Adobe "
             "VIP account to Adobe VIP Marketplace."
         ),
-        "display_order": 101,
+        "display_order": 100,
         "external_id": "agreementType",
         "name": "Agreement type",
         "phase": "Order",
@@ -37,7 +35,7 @@ def test_parameters_data_from_dict(parameters_file_data):
     } == expected_data
 
 
-def test_parameters_data_from_json(mpt_agreement_parameter_data):
+def test_parameters_data_from_json(date_factory, mpt_agreement_parameter_data):
     result = AgreementParametersData.from_json(mpt_agreement_parameter_data)
 
     expected_data = {
@@ -47,7 +45,7 @@ def test_parameters_data_from_json(mpt_agreement_parameter_data):
             "to create a new Adobe VIP Marketplace account or migrate your existing Adobe "
             "VIP account to Adobe VIP Marketplace."
         ),
-        "display_order": 101,
+        "display_order": 100,
         "external_id": "agreementType",
         "name": "Agreement type",
         "phase": "Order",
@@ -90,8 +88,8 @@ def test_parameters_data_from_json(mpt_agreement_parameter_data):
         },
         "group_id": "PGR-0232-2541-0002",
         "group_id_coordinate": None,
-        "created_date": dt.date(2024, 3, 19),
-        "updated_date": dt.date(2024, 3, 19),
+        "created_date": date_factory("2024-03-19"),
+        "updated_date": date_factory("2024-03-19"),
     }
     assert {
         field_name: getattr(result, field_name) for field_name in expected_data
@@ -144,13 +142,13 @@ def test_parameters_data_to_json(parameters_data_from_dict):
         },
         "constraints": {"hidden": False, "readonly": False, "optional": True, "required": False},
         "externalId": "agreementType",
-        "displayOrder": 101,
+        "displayOrder": 100,
         "group": {"id": "PGR-0232-2541-0001"},
     }
     assert result["options"].get("label") is None
 
 
-def test_parameters_data_to_xlsx(parameters_data_from_json):
+def test_parameters_data_to_xlsx(date_factory, parameters_data_from_json):
     result = parameters_data_from_json.to_xlsx()
 
     assert result == {
@@ -165,7 +163,7 @@ def test_parameters_data_to_xlsx(parameters_data_from_json):
             "the option to create a new Adobe VIP Marketplace account or "
             "migrate your existing Adobe VIP account to Adobe VIP Marketplace."
         ),
-        product_constants.PARAMETERS_DISPLAY_ORDER: 101,
+        product_constants.PARAMETERS_DISPLAY_ORDER: 100,
         product_constants.PARAMETERS_GROUP_ID: "PGR-0232-2541-0002",
         product_constants.PARAMETERS_GROUP_NAME: "Create agreement",
         product_constants.PARAMETERS_OPTIONS: (
@@ -192,8 +190,8 @@ def test_parameters_data_to_xlsx(parameters_data_from_json):
         product_constants.PARAMETERS_CONSTRAINTS: (
             '{"hidden": false, "readonly": false, "required": true}'
         ),
-        product_constants.PARAMETERS_CREATED: dt.date(2024, 3, 19),
-        product_constants.PARAMETERS_MODIFIED: dt.date(2024, 3, 19),
+        product_constants.PARAMETERS_CREATED: date_factory("2024-03-19"),
+        product_constants.PARAMETERS_MODIFIED: date_factory("2024-03-19"),
     }
 
 

--- a/tests/cli/core/products/models/test_parameters.py
+++ b/tests/cli/core/products/models/test_parameters.py
@@ -9,84 +9,93 @@ from cli.core.products.models.parameters import ParamScopeEnum
 def test_parameters_data_from_dict(parameters_file_data):
     result = AgreementParametersData.from_dict(parameters_file_data)
 
-    assert result.id == "PAR-5159-0756-0001"
-    assert result.coordinate == "A325"
-    assert (
-        result.description
-        == "When you are creating a new agreement with SoftwareOne, you have the option to create "
-        "a new Adobe VIP Marketplace account or migrate your existing Adobe VIP account to "
-        "Adobe VIP Marketplace."
-    )
-    assert result.display_order == 101
-    assert result.external_id == "agreementType"
-    assert result.name == "Agreement type"
-    assert result.phase == "Order"
-    assert result.type == "Choice"
-    assert result.constraints == {
-        "hidden": False,
-        "readonly": False,
-        "optional": False,
-        "required": True,
+    expected_data = {
+        "id": "PAR-5159-0756-0001",
+        "coordinate": "A325",
+        "description": (
+            "When you are creating a new agreement with SoftwareOne, you have the option "
+            "to create a new Adobe VIP Marketplace account or migrate your existing Adobe "
+            "VIP account to Adobe VIP Marketplace."
+        ),
+        "display_order": 101,
+        "external_id": "agreementType",
+        "name": "Agreement type",
+        "phase": "Order",
+        "type": "Choice",
+        "constraints": {
+            "hidden": False,
+            "readonly": False,
+            "optional": False,
+            "required": True,
+        },
+        "options": {"defaultValue": "Buyer", "hintText": "Address.", "label": "Address"},
+        "group_id": "PGR-5159-0756-0002",
+        "group_id_coordinate": "I325",
     }
-    assert result.options == {"defaultValue": "Buyer", "hintText": "Address.", "label": "Address"}
-    assert result.group_id == "PGR-5159-0756-0002"
-    assert result.group_id_coordinate == "I325"
+    assert {
+        field_name: getattr(result, field_name) for field_name in expected_data
+    } == expected_data
 
 
 def test_parameters_data_from_json(mpt_agreement_parameter_data):
     result = AgreementParametersData.from_json(mpt_agreement_parameter_data)
 
-    assert result.id == "PAR-0232-2541-0001"
-    assert (
-        result.description
-        == "When you are creating a new agreement with SoftwareOne, you have the option to create "
-        "a new Adobe VIP Marketplace account or migrate your existing Adobe VIP account to "
-        "Adobe VIP Marketplace."
-    )
-    assert result.display_order == 101
-    assert result.external_id == "agreementType"
-    assert result.name == "Agreement type"
-    assert result.phase == "Order"
-    assert result.type == "Choice"
-    assert result.constraints == {
-        "hidden": False,
-        "readonly": False,
-        "required": True,
+    expected_data = {
+        "id": "PAR-0232-2541-0001",
+        "description": (
+            "When you are creating a new agreement with SoftwareOne, you have the option "
+            "to create a new Adobe VIP Marketplace account or migrate your existing Adobe "
+            "VIP account to Adobe VIP Marketplace."
+        ),
+        "display_order": 101,
+        "external_id": "agreementType",
+        "name": "Agreement type",
+        "phase": "Order",
+        "type": "Choice",
+        "constraints": {
+            "hidden": False,
+            "readonly": False,
+            "required": True,
+        },
+        "options": {
+            "optionsList": [
+                {
+                    "label": "Create account",
+                    "value": "New",
+                    "description": "Create a new Adobe VIP Marketplace account if you have never "
+                    "purchased Adobe products before, or if you wish to set up an "
+                    "new account in addition to an account you may already have. "
+                    "You will need to provide details such as your company address "
+                    "and contacts, and you will be required to accept both the Adobe"
+                    " Terms and Conditions as well as SoftwareOne's terms and "
+                    "conditions.",
+                },
+                {
+                    "label": "Migrate account",
+                    "value": "Migrate",
+                    "description": "Migrate from Adobe VIP if you are currently purchasing "
+                    "products "
+                    "under the Adobe VIP licensing program. This comes with several "
+                    "advantages including the ability to self-service manage your "
+                    "subscriptions within the SoftwareOne Marketplace. You will need to "
+                    "provide details such as your company address and contacts, and you "
+                    "will be required to accept both the Adobe Terms and Conditions as "
+                    "well as SoftwareOne's terms and conditions.\n\nNote: If you are "
+                    "purchasing Adobe products under a different licensing program such "
+                    "as CLP or TLP, you cannot use this option.",
+                },
+            ],
+            "defaultValue": "New",
+            "hintText": "Some hint text",
+        },
+        "group_id": "PGR-0232-2541-0002",
+        "group_id_coordinate": None,
+        "created_date": dt.date(2024, 3, 19),
+        "updated_date": dt.date(2024, 3, 19),
     }
-    assert result.options == {
-        "optionsList": [
-            {
-                "label": "Create account",
-                "value": "New",
-                "description": "Create a new Adobe VIP Marketplace account if you have never "
-                "purchased Adobe products before, or if you wish to set up an "
-                "new account in addition to an account you may already have. "
-                "You will need to provide details such as your company address "
-                "and contacts, and you will be required to accept both the Adobe"
-                " Terms and Conditions as well as SoftwareOne's terms and "
-                "conditions.",
-            },
-            {
-                "label": "Migrate account",
-                "value": "Migrate",
-                "description": "Migrate from Adobe VIP if you are currently purchasing products "
-                "under the Adobe VIP licensing program. This comes with several "
-                "advantages including the ability to self-service manage your "
-                "subscriptions within the SoftwareOne Marketplace. You will need to "
-                "provide details such as your company address and contacts, and you "
-                "will be required to accept both the Adobe Terms and Conditions as "
-                "well as SoftwareOne's terms and conditions.\n\nNote: If you are "
-                "purchasing Adobe products under a different licensing program such "
-                "as CLP or TLP, you cannot use this option.",
-            },
-        ],
-        "defaultValue": "New",
-        "hintText": "Some hint text",
-    }
-    assert result.group_id == "PGR-0232-2541-0002"
-    assert result.group_id_coordinate is None
-    assert result.created_date == dt.date(2024, 3, 19)
-    assert result.updated_date == dt.date(2024, 3, 19)
+    assert {
+        field_name: getattr(result, field_name) for field_name in expected_data
+    } == expected_data
 
 
 def test_parameters_data_to_json(parameters_data_from_dict):

--- a/tests/cli/core/products/models/test_product.py
+++ b/tests/cli/core/products/models/test_product.py
@@ -1,9 +1,9 @@
-import datetime as dt
-
 from cli.core.products import constants as product_constants
 from cli.core.products.models import DataActionEnum
 from cli.core.products.models.product import ProductData, SettingsData, SettingsRecords
 from freezegun import freeze_time
+
+SETTINGS_RECORDS_COUNT = 11
 
 
 def test_product_data_from_dict(product_file_data):
@@ -22,7 +22,7 @@ def test_product_data_from_dict(product_file_data):
     } == expected_data
 
 
-def test_product_data_from_json(mpt_product_data):
+def test_product_data_from_json(date_factory, mpt_product_data):
     with freeze_time("2025-05-30"):
         result = ProductData.from_json(mpt_product_data)
 
@@ -45,10 +45,10 @@ def test_product_data_from_json(mpt_product_data):
             "MTYgMTguNjQ4NloiIGZpbGw9IiNGQTBDMDAiLz4KPC9zdmc+"
         ),
         "website": "https://www.adobe.com/",
-        "export_date": dt.date(2025, 5, 30),
+        "export_date": date_factory("2025-05-30"),
         "status": "Unpublished",
-        "created_date": dt.date(2024, 3, 19),
-        "updated_date": dt.date(2025, 6, 3),
+        "created_date": date_factory("2024-03-19"),
+        "updated_date": date_factory("2025-06-03"),
     }
     assert {
         field_name: getattr(result, field_name) for field_name in expected_data
@@ -67,7 +67,7 @@ def test_product_data_to_json(product_data_from_dict):
     }
 
 
-def test_product_to_xlsx(product_data_from_json):
+def test_product_to_xlsx(date_factory, product_data_from_json):
     result = product_data_from_json.to_xlsx()
 
     assert result == {
@@ -89,10 +89,10 @@ def test_product_to_xlsx(product_data_from_json):
         product_constants.GENERAL_PRODUCT_WEBSITE: "https://www.adobe.com/",
         product_constants.GENERAL_ACCOUNT_ID: "ACC-9226-9856",
         product_constants.GENERAL_ACCOUNT_NAME: "Adobe",
-        product_constants.GENERAL_EXPORT_DATE: dt.date(2025, 5, 30),
+        product_constants.GENERAL_EXPORT_DATE: date_factory("2025-05-30"),
         product_constants.GENERAL_STATUS: "Unpublished",
-        product_constants.GENERAL_CREATED: dt.date(2024, 3, 19),
-        product_constants.GENERAL_MODIFIED: dt.date(2025, 6, 3),
+        product_constants.GENERAL_CREATED: date_factory("2024-03-19"),
+        product_constants.GENERAL_MODIFIED: date_factory("2025-06-03"),
     }
 
 
@@ -128,7 +128,7 @@ def test_settings_data_from_dict(settings_file_data):
 def test_settings_data_from_json(mpt_product_data):
     result = SettingsData.from_json(mpt_product_data["settings"])
 
-    assert len(result.records) == 11
+    assert len(result.records) == SETTINGS_RECORDS_COUNT
     assert isinstance(result.records[0], SettingsRecords)
     assert result.json_path is None
 

--- a/tests/cli/core/products/models/test_product.py
+++ b/tests/cli/core/products/models/test_product.py
@@ -9,40 +9,50 @@ from freezegun import freeze_time
 def test_product_data_from_dict(product_file_data):
     result = ProductData.from_dict(product_file_data)
 
-    assert result.id == "PRD-1234-1234-1234"
-    assert result.coordinate == "B3"
-    assert result.name == "Test Product Name"
-    assert result.short_description == "Catalog description"
-    assert result.long_description == "Product description"
-    assert result.website == "https://example.com"
+    expected_data = {
+        "id": "PRD-1234-1234-1234",
+        "coordinate": "B3",
+        "name": "Test Product Name",
+        "short_description": "Catalog description",
+        "long_description": "Product description",
+        "website": "https://example.com",
+    }
+    assert {
+        field_name: getattr(result, field_name) for field_name in expected_data
+    } == expected_data
 
 
 def test_product_data_from_json(mpt_product_data):
     with freeze_time("2025-05-30"):
         result = ProductData.from_json(mpt_product_data)
 
-    assert result.id == "PRD-0232-2541"
-    assert result.name == "Adobe VIP Marketplace for Commercial"
-    assert result.account_id == "ACC-9226-9856"
-    assert result.account_name == "Adobe"
-    assert result.short_description == (
-        "Adobe's groundbreaking innovations empower everyone, everywhere to imagine, "
-        "create, and bring any digital experience to life."
-    )
-    assert result.long_description == (
-        "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwM"
-        "C9zdmciIHdpZHRoPSI0OCIgaGVpZ2h0PSI0OCIgdmlld0JveD0iMCAwIDQ4IDQ4IiBmaWxs"
-        "PSJub25lIj4KICA8cGF0aCBkPSJNMTcuNzYyOCAzSDBWNDUuNDU4MkwxNy43NjI4IDNaIiB"
-        "maWxsPSIjRkEwQzAwIi8+CiAgPHBhdGggZD0iTTMwLjI2MDQgM0g0OFY0NS40NTgyTDMwLj"
-        "I2MDQgM1oiIGZpbGw9IiNGQTBDMDAiLz4KICA8cGF0aCBkPSJNMjQuMDExNiAxOC42NDg2T"
-        "DM1LjMxNzMgNDUuNDU4MkgyNy44OTk3TDI0LjUyMDggMzYuOTIyNkgxNi4yNDY5TDI0LjAx"
-        "MTYgMTguNjQ4NloiIGZpbGw9IiNGQTBDMDAiLz4KPC9zdmc+"
-    )
-    assert result.website == "https://www.adobe.com/"
-    assert result.export_date == dt.date(2025, 5, 30)
-    assert result.status == "Unpublished"
-    assert result.created_date == dt.date(2024, 3, 19)
-    assert result.updated_date == dt.date(2025, 6, 3)
+    expected_data = {
+        "id": "PRD-0232-2541",
+        "name": "Adobe VIP Marketplace for Commercial",
+        "account_id": "ACC-9226-9856",
+        "account_name": "Adobe",
+        "short_description": (
+            "Adobe's groundbreaking innovations empower everyone, everywhere to imagine, "
+            "create, and bring any digital experience to life."
+        ),
+        "long_description": (
+            "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwM"
+            "C9zdmciIHdpZHRoPSI0OCIgaGVpZ2h0PSI0OCIgdmlld0JveD0iMCAwIDQ4IDQ4IiBmaWxs"
+            "PSJub25lIj4KICA8cGF0aCBkPSJNMTcuNzYyOCAzSDBWNDUuNDU4MkwxNy43NjI4IDNaIiB"
+            "maWxsPSIjRkEwQzAwIi8+CiAgPHBhdGggZD0iTTMwLjI2MDQgM0g0OFY0NS40NTgyTDMwLj"
+            "I2MDQgM1oiIGZpbGw9IiNGQTBDMDAiLz4KICA8cGF0aCBkPSJNMjQuMDExNiAxOC42NDg2T"
+            "DM1LjMxNzMgNDUuNDU4MkgyNy44OTk3TDI0LjUyMDggMzYuOTIyNkgxNi4yNDY5TDI0LjAx"
+            "MTYgMTguNjQ4NloiIGZpbGw9IiNGQTBDMDAiLz4KPC9zdmc+"
+        ),
+        "website": "https://www.adobe.com/",
+        "export_date": dt.date(2025, 5, 30),
+        "status": "Unpublished",
+        "created_date": dt.date(2024, 3, 19),
+        "updated_date": dt.date(2025, 6, 3),
+    }
+    assert {
+        field_name: getattr(result, field_name) for field_name in expected_data
+    } == expected_data
     assert result.settings is not None
 
 
@@ -96,13 +106,23 @@ def test_settings_data_from_dict(settings_file_data):
         product_constants.SETTINGS_VALUE: {"value": "Enabled", "coordinate": "C2"},
     })
 
-    assert len(result.records) == 1
     setting_item = result.records[0]
-    assert isinstance(setting_item, SettingsRecords)
-    assert setting_item.name == "Change order validation (draft)"
-    assert setting_item.setting_value == "Enabled"
-    assert setting_item.coordinate == "A2"
-    assert result.json_path is None
+    expected_data = {
+        "records_length": len(result.records),
+        "record_type": isinstance(setting_item, SettingsRecords),
+        "name": setting_item.name,
+        "setting_value": setting_item.setting_value,
+        "coordinate": setting_item.coordinate,
+        "json_path": result.json_path,
+    }
+    assert expected_data == {
+        "records_length": 1,
+        "record_type": True,
+        "name": "Change order validation (draft)",
+        "setting_value": "Enabled",
+        "coordinate": "A2",
+        "json_path": None,
+    }
 
 
 def test_settings_data_from_json(mpt_product_data):

--- a/tests/cli/core/products/models/test_template.py
+++ b/tests/cli/core/products/models/test_template.py
@@ -16,29 +16,39 @@ from cli.core.products.models import DataActionEnum, TemplateData
 def test_template_data_from_dict(template_file_data):
     result = TemplateData.from_dict(template_file_data)
 
-    assert result.id == "TPL-0232-2541-0005"
-    assert result.coordinate == "A3"
-    assert result.action == "-"
-    assert result.name == "BulkMigrate"
-    assert result.type == "OrderCompleted"
-    assert result.template_content == "Querying template for Adobe VIP Marketplace"
-    assert result.content_coordinate == "F3"
-    assert result.default is False
+    expected_data = {
+        "id": "TPL-0232-2541-0005",
+        "coordinate": "A3",
+        "action": "-",
+        "name": "BulkMigrate",
+        "type": "OrderCompleted",
+        "template_content": "Querying template for Adobe VIP Marketplace",
+        "content_coordinate": "F3",
+        "default": False,
+    }
+    assert {
+        field_name: getattr(result, field_name) for field_name in expected_data
+    } == expected_data
 
 
 def test_template_data_from_json(mpt_template_data):
     result = TemplateData.from_json(mpt_template_data)
 
-    assert result.id == "TPL-0232-2541-0005"
-    assert result.name == "Default Processing Template"
-    assert result.type == "OrderProcessing"
-    assert result.template_content == (
-        "#Thanks you for your order  Sit back and enjoy {{ PAR-0232-2541-0002 }} while "
-        "we are working on your order."
-    )
-    assert result.default is False
-    assert result.created_date == dt.date(2024, 4, 8)
-    assert result.updated_date == dt.date(2024, 5, 3)
+    expected_data = {
+        "id": "TPL-0232-2541-0005",
+        "name": "Default Processing Template",
+        "type": "OrderProcessing",
+        "template_content": (
+            "#Thanks you for your order  Sit back and enjoy {{ PAR-0232-2541-0002 }} while "
+            "we are working on your order."
+        ),
+        "default": False,
+        "created_date": dt.date(2024, 4, 8),
+        "updated_date": dt.date(2024, 5, 3),
+    }
+    assert {
+        field_name: getattr(result, field_name) for field_name in expected_data
+    } == expected_data
 
 
 def test_template_data_to_json(template_data_from_dict):

--- a/tests/cli/core/products/models/test_template.py
+++ b/tests/cli/core/products/models/test_template.py
@@ -1,5 +1,3 @@
-import datetime as dt
-
 from cli.core.products.constants import (
     TEMPLATES_ACTION,
     TEMPLATES_CONTENT,
@@ -31,7 +29,7 @@ def test_template_data_from_dict(template_file_data):
     } == expected_data
 
 
-def test_template_data_from_json(mpt_template_data):
+def test_template_data_from_json(date_factory, mpt_template_data):
     result = TemplateData.from_json(mpt_template_data)
 
     expected_data = {
@@ -43,8 +41,8 @@ def test_template_data_from_json(mpt_template_data):
             "we are working on your order."
         ),
         "default": False,
-        "created_date": dt.date(2024, 4, 8),
-        "updated_date": dt.date(2024, 5, 3),
+        "created_date": date_factory("2024-04-08"),
+        "updated_date": date_factory("2024-05-03"),
     }
     assert {
         field_name: getattr(result, field_name) for field_name in expected_data
@@ -84,7 +82,7 @@ def test_template_data_to_json(template_data_from_dict):
     }
 
 
-def test_template_to_xlsx(template_data_from_json):
+def test_template_to_xlsx(date_factory, template_data_from_json):
     result = template_data_from_json.to_xlsx()
 
     assert result == {
@@ -97,6 +95,6 @@ def test_template_to_xlsx(template_data_from_json):
             "#Thanks you for your order  Sit back and enjoy {{ PAR-0232-2541-0002 }} while we "
             "are working on your order."
         ),
-        TEMPLATES_CREATED: dt.date(2024, 4, 8),
-        TEMPLATES_MODIFIED: dt.date(2024, 5, 3),
+        TEMPLATES_CREATED: date_factory("2024-04-08"),
+        TEMPLATES_MODIFIED: date_factory("2024-05-03"),
     }

--- a/tests/cli/core/test_error_wrappers.py
+++ b/tests/cli/core/test_error_wrappers.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from types import SimpleNamespace
 
 import pytest
@@ -12,7 +13,7 @@ def error_factory():
 
 @pytest.fixture
 def http_error_callable(mocker):
-    return mocker.Mock(side_effect=MPTHttpError(500, "err", "boom"))
+    return mocker.Mock(side_effect=MPTHttpError(HTTPStatus.INTERNAL_SERVER_ERROR, "err", "boom"))
 
 
 def test_http_wrapper_get_from_class(error_factory):

--- a/tests/cli/plugins/audit_plugin/test_audit_records.py
+++ b/tests/cli/plugins/audit_plugin/test_audit_records.py
@@ -46,6 +46,17 @@ def test_format_json_path(path, source, target, expected_result):
 
 
 def test_display_records(capsys):
+    expected_output_fragments = (
+        "Available Audit Records",
+        "2024-01-01T10:00:00Z",
+        "audit1",
+        "Test User",
+        "(Test",
+        "Account)",
+        "create",
+        "Created",
+        "object",
+    )
     records = [
         {
             "id": "audit1",
@@ -60,15 +71,7 @@ def test_display_records(capsys):
 
     captured = capsys.readouterr()
     output = captured.out
-    assert "Available Audit Records" in output
-    assert "2024-01-01T10:00:00Z" in output
-    assert "audit1" in output
-    assert "Test User" in output
-    assert "(Test" in output
-    assert "Account)" in output
-    assert "create" in output
-    assert "Created" in output
-    assert "object" in output
+    assert all(fragment in output for fragment in expected_output_fragments)
 
 
 def test_display_records_missing_fields(capsys):


### PR DESCRIPTION
## Summary
Removes `# noqa: WPS218` and `# noqa: WPS432` inline ignore comments from test files as part of MPT-17825 cleanup.
## Changes
- Remove `WPS432` (magic number) test ignores
- Remove `WPS218` (too many `assert` statements) test ignores
## Jira
[MPT-17825](https://softwareone.atlassian.net/browse/MPT-17825)

[MPT-17825]: https://softwareone.atlassian.net/browse/MPT-17825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-17825](https://softwareone.atlassian.net/browse/MPT-17825)

- Removed `WPS218` (too many `assert` statements) and `WPS432` (magic numbers) from Flake8 per-file-ignores in `pyproject.toml` for test files
- Refactored test assertions to comply with stricter linting rules:
  - Consolidated multiple per-field assertions into single `assert` statements using `expected_data` dictionaries in price list, product, parameter, and item group tests
  - Replaced hard-coded HTTP status codes with `http.HTTPStatus` constants (e.g., `HTTPStatus.BAD_REQUEST`, `HTTPStatus.INTERNAL_SERVER_ERROR`)
- Introduced `date_factory` and `datetime_factory` pytest fixtures in core conftest to generate date/datetime values from ISO format strings, replacing hard-coded `datetime` literals and magic number values
- Updated test fixtures to use the new factory fixtures, reducing magic number values (e.g., changing `42.0` to `1.0`, `101` to `100`)
- Updated expected test data and assertions to align with normalized fixture values for pricing, parameters, and product metadata

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softwareone-platform/swo-marketplace-cli/pull/219)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->