### PR TITLE
MPT-21850 use shared CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,3 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 remote_config:
-  url: "https://raw.githubusercontent.com/softwareone-platform/swo-extension-playground/refs/heads/main/.coderabbit.yaml"
+  url: "https://raw.githubusercontent.com/softwareone-platform/mpt-extension-skills/main/coderabbit-shared.yaml"


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What changed
- Updated the CodeRabbit remote configuration URL to use mpt-extension-skills/coderabbit-shared.yaml from main.
- Removed the indirect dependency on swo-extension-playground's CodeRabbit configuration.

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".coderabbit.yaml")'
- curl -L -sSf -o /tmp/swo-marketplace-cli-coderabbit-shared.yaml https://raw.githubusercontent.com/softwareone-platform/mpt-extension-skills/main/coderabbit-shared.yaml
- git diff --check -- .coderabbit.yaml

Closes [MPT-21850](https://softwareone.atlassian.net/browse/MPT-21850)

[MPT-21850]: https://softwareone.atlassian.net/browse/MPT-21850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-21850](https://softwareone.atlassian.net/browse/MPT-21850)

- Updated CodeRabbit remote configuration to use shared `coderabbit-shared.yaml` from `mpt-extension-skills` repository
- Removed indirect dependency on `swo-extension-playground`'s CodeRabbit configuration
- CLI now points directly to the shared configuration used by extension repositories for consistent review rules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->