### PR TITLE
MPT-21857 pin SonarCloud scan action

### DIFF
--- a/.github/workflows/pr-build-merge.yml
+++ b/.github/workflows/pr-build-merge.yml
@@ -30,7 +30,7 @@ jobs:
       run: make check-all
 
     - name: "Run SonarCloud Scan"
-      uses: SonarSource/sonarqube-scan-action@master
+      uses: SonarSource/sonarqube-scan-action@v8.0.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What changed
- Replaced the SonarCloud scan action branch reference with the requested released tag: `SonarSource/sonarqube-scan-action@v8.0.0`.
- Checked the remaining GitHub Actions references; none use `main` or `master` branch refs.

## Testing
- `make check-all`

Closes [MPT-21857](https://softwareone.atlassian.net/browse/MPT-21857)

[MPT-21857]: https://softwareone.atlassian.net/browse/MPT-21857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ