### PR TITLE
MPT-22056 swo-marketplace-cli documentation fixes

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,7 +37,7 @@ The products domain owns product definition import and export.
 
 - Marketplace-facing models live under [`cli/core/products/models/`](../cli/core/products/models)
 - file import and export logic lives under [`cli/core/products/handlers/`](../cli/core/products/handlers)
-- workflow orchestration lives in [`cli/core/products/app.py`](../cli/core/products/app.py) and the related services
+- workflow orchestration lives under [`cli/core/products/app/`](../cli/core/products/app) (entry point [`app/app.py`](../cli/core/products/app/app.py)) and the related services
 
 ### Price Lists
 


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What
Documentation fix for swo-marketplace-cli (MPT-22056, under MPT-22048).

- **docs/architecture.md**: `cli/core/products/app` is a package **directory** (`sync.py`, `list_products.py`, `export.py`, `app.py`), not a single `app.py` file. The architecture link now points at the directory and its `app/app.py` entry point.

## docs/migrations.md — intentionally not added
The audit recommends `migrations.md` because a `migrations/` directory exists, but it contains only a `.gitkeep` placeholder — there are no migration files and no migration make targets, so there is no migration workflow to document.

## Testing
- Markdown-only change. (Note: the repo's `pre-commit` python-hook environment currently fails to build `pydantic-core` locally — unrelated to this docs change; no `.py` files are touched.)

Subtask: MPT-22056 (parent MPT-22048).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-22056](https://softwareone.atlassian.net/browse/MPT-22056)

## Release Notes

- Corrected architecture documentation to properly reference `cli/core/products/app/` as a package directory containing multiple files (sync.py, list_products.py, export.py, app.py) with `app/app.py` as the entry point, rather than a single module file

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-22056]: https://softwareone.atlassian.net/browse/MPT-22056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ