### PR TITLE
MPT-22662 Bump one-danger action to 1.2.0

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -19,6 +19,6 @@ jobs:
           fetch-depth: 0
 
       - name: Run Danger
-        uses: softwareone-platform/one-danger@1.1.0
+        uses: softwareone-platform/one-danger@1.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Bump the Danger action `softwareone-platform/one-danger` `@1.1.0` → `@1.2.0` in `.github/workflows/danger.yml`.

## Why

one-danger 1.2.0 ships the undici-based `danger` build ([MPT-22661](https://softwareone.atlassian.net/browse/MPT-22661)) that fixes the Danger check failing with `FetchError: ERR_STREAM_PREMATURE_CLOSE` on Node 24 runners. Consumers pin the action by exact tag, so each repo needs an explicit bump. Part of the fleet-wide rollout tracked by [MPT-22662](https://softwareone.atlassian.net/browse/MPT-22662).

## Testing

Config-only one-line change; the bumped action runs on this PR's own Danger check.


[MPT-22661]: https://softwareone.atlassian.net/browse/MPT-22661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MPT-22662]: https://softwareone.atlassian.net/browse/MPT-22662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ