### PR TITLE
MPT-22771: add run-name to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release
+run-name: Release (v${{ inputs.version }})
 
 # Manually-triggered release pipeline for this Python package. Runs against the
 # branch selected at dispatch time (main -> pre-release, release/* -> latest).


### PR DESCRIPTION
## What

Adds the `run-name` property to the release workflow so each manually-dispatched run shows the version in its title:

```yaml
run-name: Release (v${{ inputs.version }})
```

## Why

Improves traceability of release runs in the GitHub Actions UI — the run is labelled with the released version instead of a generic "Release".

## Notes

- Inserted right below `name: Release`; no other changes.
- The workflow is dispatched manually (`workflow_dispatch`) with a required `version` input, so `inputs.version` is always populated.

Jira: **MPT-22771** (parent MPT-21906)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added a dynamic GitHub Actions `run-name` to the release workflow so manual release runs display `Release (v${{ inputs.version }})`.
- Improves traceability in the Actions UI by surfacing the released version instead of a generic label.
- No workflow logic was changed beyond the run title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->