### PR TITLE
MPT-23414 Adopt ruff 0.15.22 conventions and drop RUF105/RUF201 ignores

### DIFF
--- a/cli/core/accounts/app.py
+++ b/cli/core/accounts/app.py
@@ -131,7 +131,7 @@ def extract_account(
 
 @app.command(name="list")
 def list_accounts(
-    active_only: Annotated[  # noqa: FBT002
+    active_only: Annotated[  # ruff:ignore[boolean-default-value-positional-argument]
         bool, typer.Option("--active", "-a", help="Show only current active account")
     ] = False,
 ):

--- a/cli/core/products/app/sync.py
+++ b/cli/core/products/app/sync.py
@@ -173,7 +173,7 @@ def sync_product(
         str,
         typer.Argument(help="Path to Product Definition file", metavar="PRODUCT-PATH"),
     ],
-    is_dry_run: Annotated[  # noqa: FBT002
+    is_dry_run: Annotated[  # ruff:ignore[boolean-default-value-positional-argument]
         bool,
         typer.Option(
             "--dry-run",
@@ -181,7 +181,7 @@ def sync_product(
             help="Do not sync Product Definition. Check the file consistency only.",
         ),
     ] = False,
-    force_create: Annotated[  # noqa: FBT002
+    force_create: Annotated[  # ruff:ignore[boolean-default-value-positional-argument]
         bool,
         typer.Option(
             "--force-create",

--- a/cli/core/products/services/related_components_base_service.py
+++ b/cli/core/products/services/related_components_base_service.py
@@ -75,7 +75,7 @@ class RelatedComponentsActionMixin:
 
         if model_action == DataActionEnum.DELETE:
             # TODO: uncomment once the delete action is supported
-            # return self._action_delete_item   # noqa: ERA001
+            # return self._action_delete_item   # ruff:ignore[commented-out-code]
             raise ValueError(f"Action type {model_action} is not supported")
 
         if model_action == DataActionEnum.UPDATE:

--- a/cli/swocli.py
+++ b/cli/swocli.py
@@ -32,7 +32,7 @@ def get_version() -> str:
     return __version__
 
 
-def version_callback(show_version: bool) -> None:  # noqa: FBT001
+def version_callback(show_version: bool) -> None:  # ruff:ignore[boolean-type-hint-positional-argument]
     """Callback to display the CLI version and exit if requested.
 
     Args:
@@ -50,7 +50,7 @@ def main(
         bool | None,
         typer.Option("--version", callback=version_callback, is_eager=True),
     ] = None,
-    verbose: Annotated[  # noqa: FBT002
+    verbose: Annotated[  # ruff:ignore[boolean-default-value-positional-argument]
         bool,
         typer.Option(
             "--verbose",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,35 +169,33 @@ select = [
   "SIM",  # flake8-simpify
   "SLF",  # flake8-self
   "SLOT", # flake8-slots
-  "T100", # flake8-debugger
+  "debugger", # flake8-debugger
   "TRY",  # tryceratops
   "UP",   # pyupgrade
   "W",    # pycodestyle
   "YTT",  # flake8-2020
 ]
 ignore = [
-  "A005",   # allow to shadow stdlib and builtin module names
-  "B904",  # Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
-  "COM812", # trailing comma, conflicts with `ruff format`
+  "stdlib-module-shadowing",   # allow to shadow stdlib and builtin module names
+  "raise-without-from-inside-except",  # Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
+  "missing-trailing-comma", # trailing comma, conflicts with `ruff format`
   # Different doc rules that we don't really care about:
-  "D100",
-  "D104",
-  "D105", # docstring for magic methods
-  "D106",
-  "D107",
-  "D203",
-  "D212",
-  "D401",
-  "D404",
-  "D405",
-  "ISC001",  # implicit string concat conflicts with `ruff format`
-  "ISC003",  # prefer explicit string concat over implicit concat
+  "undocumented-public-module",
+  "undocumented-public-package",
+  "undocumented-magic-method", # docstring for magic methods
+  "undocumented-public-nested-class",
+  "undocumented-public-init",
+  "incorrect-blank-line-before-class",
+  "multi-line-summary-first-line",
+  "non-imperative-mood",
+  "docstring-starts-with-this",
+  "non-capitalized-section-name",
+  "single-line-implicit-string-concatenation",  # implicit string concat conflicts with `ruff format`
+  "explicit-string-concatenation",  # prefer explicit string concat over implicit concat
   "PLR09",   # we have our own complexity rules
-  "PLR2004", # do not report magic numbers
-  "PLR6301", # do not require classmethod / staticmethod when self not used
-  "RUF105", # `# noqa` vs `# ruff:ignore` migration (new rule in ruff 0.15.22)
-  "RUF201", # rule codes in selectors (new rule in ruff 0.15.22)
-  "TRY003",  # long exception messages from `tryceratops`
+  "magic-value-comparison", # do not report magic numbers
+  "no-self-use", # do not require classmethod / staticmethod when self not used
+  "raise-vanilla-args",  # long exception messages from `tryceratops`
 ]
 external = [ "AAA", "WPS" ]
 
@@ -219,15 +217,15 @@ ignore-decorators = ["property"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*.py" = [
-  "D101", # missing docstring in public class
-  "D102", # missing docstring in publich method
-  "D103", # missing docstring in public function
-  "PT011", # pytest.raises({exception}) is too broad, set the match parameter or use a more specific exception
-  "S101", # asserts
-  "S105", # hardcoded passwords
-  "S404", # subprocess calls are for tests
-  "S603", # do not require `shell=True`
-  "S607", # partial executable paths
+  "undocumented-public-class", # missing docstring in public class
+  "undocumented-public-method", # missing docstring in publich method
+  "undocumented-public-function", # missing docstring in public function
+  "pytest-raises-too-broad", # pytest.raises({exception}) is too broad, set the match parameter or use a more specific exception
+  "assert", # asserts
+  "hardcoded-password-string", # hardcoded passwords
+  "suspicious-subprocess-import", # subprocess calls are for tests
+  "subprocess-without-shell-equals-true", # do not require `shell=True`
+  "start-process-with-partial-path", # partial executable paths
 ]
 
 [tool.ruff.lint.isort]

--- a/tests/cli/core/accounts/conftest.py
+++ b/tests/cli/core/accounts/conftest.py
@@ -37,8 +37,8 @@ def inactive_vendor_account():
         id="ACC-12342",
         name="Account 2",
         type="Vendor",
-        token="idt:TKN-1111-1112:secret2",  # noqa: S106
-        token_id="TKN-1111-1112",  # noqa: S106
+        token="idt:TKN-1111-1112:secret2",  # ruff:ignore[hardcoded-password-func-arg]
+        token_id="TKN-1111-1112",  # ruff:ignore[hardcoded-password-func-arg]
         environment="https://example.com",
         is_active=False,
     )

--- a/tests/cli/core/accounts/test_app.py
+++ b/tests/cli/core/accounts/test_app.py
@@ -20,7 +20,7 @@ def vendor_token():
             name="New Account",
             type="Vendor",
         ),
-        token="idt:TKN-1111-1111:secret",  # noqa: S106
+        token="idt:TKN-1111-1111:secret",  # ruff:ignore[hardcoded-password-func-arg]
     )
 
 

--- a/tests/cli/core/accounts/test_flows.py
+++ b/tests/cli/core/accounts/test_flows.py
@@ -27,7 +27,7 @@ def test_from_token(active_vendor_account):
             name="Account 1",
             type="Vendor",
         ),
-        token="idt:TKN-1111-1111:secret",  # noqa: S106
+        token="idt:TKN-1111-1111:secret",  # ruff:ignore[hardcoded-password-func-arg]
     )
 
     result = Account.from_token(token, "https://example.com")
@@ -64,8 +64,8 @@ def test_doesnot_account_exist(stored_accounts):
             id="ACC-4321",
             name="Not exists account",
             type="Vendor",
-            token="secret",  # noqa: S106
-            token_id="TKN-0000-0000-0001",  # noqa: S106
+            token="secret",  # ruff:ignore[hardcoded-password-func-arg]
+            token_id="TKN-0000-0000-0001",  # ruff:ignore[hardcoded-password-func-arg]
             environment="https://example.com",
             is_active=False,
         ),

--- a/tests/cli/core/conftest.py
+++ b/tests/cli/core/conftest.py
@@ -78,8 +78,8 @@ def active_operations_account():
         id="ACC-12340",
         name="Account 1",
         type="Operations",
-        token="idt:TKN-1111-1111:secret",  # noqa: S106
-        token_id="TKN-1111-1111",  # noqa: S106
+        token="idt:TKN-1111-1111:secret",  # ruff:ignore[hardcoded-password-func-arg]
+        token_id="TKN-1111-1111",  # ruff:ignore[hardcoded-password-func-arg]
         environment="https://example.com",
         is_active=True,
     )
@@ -91,8 +91,8 @@ def active_vendor_account():
         id="ACC-12341",
         name="Account 1",
         type="Vendor",
-        token="idt:TKN-1111-1111:secret",  # noqa: S106
-        token_id="TKN-1111-1111",  # noqa: S106
+        token="idt:TKN-1111-1111:secret",  # ruff:ignore[hardcoded-password-func-arg]
+        token_id="TKN-1111-1111",  # ruff:ignore[hardcoded-password-func-arg]
         environment="https://example.com",
         is_active=True,
     )

--- a/tests/cli/core/handlers/test_excel_file_handler.py
+++ b/tests/cli/core/handlers/test_excel_file_handler.py
@@ -217,7 +217,7 @@ def test_get_values_for_dynamic_sheet(excel_file_handler):
 
 
 def test_dynamic_sheet_skips_non_string_headers(excel_file_handler):
-    excel_file_handler._get_worksheet("HorizontalSheet")["B1"] = 123  # noqa: SLF001
+    excel_file_handler._get_worksheet("HorizontalSheet")["B1"] = 123  # ruff:ignore[private-member-access]
     fields = ["Header1"]
     patterns = [re.compile(r"Missing\d+")]
 
@@ -236,9 +236,9 @@ def test_write(excel_file_handler):
 
     excel_file_handler.write(test_data)  # act
 
-    assert excel_file_handler._get_worksheet("VerticalSheet")["A1"].value == "ValueA1"  # noqa: SLF001
-    assert excel_file_handler._get_worksheet("FakeSheet")["D1"].value == "ValueD1"  # noqa: SLF001
-    assert excel_file_handler._get_worksheet("FakeSheet")["J23"].value == "ValueJ23"  # noqa: SLF001
+    assert excel_file_handler._get_worksheet("VerticalSheet")["A1"].value == "ValueA1"  # ruff:ignore[private-member-access]
+    assert excel_file_handler._get_worksheet("FakeSheet")["D1"].value == "ValueD1"  # ruff:ignore[private-member-access]
+    assert excel_file_handler._get_worksheet("FakeSheet")["J23"].value == "ValueJ23"  # ruff:ignore[private-member-access]
 
 
 def test_write_cell(excel_file_handler):
@@ -246,7 +246,7 @@ def test_write_cell(excel_file_handler):
 
     excel_file_handler.write_cell("Sheet1", position=cell_position, cell_value="FakeValue")  # act
 
-    cell = excel_file_handler._get_worksheet("Sheet1")["C2"]  # noqa: SLF001
+    cell = excel_file_handler._get_worksheet("Sheet1")["C2"]  # ruff:ignore[private-member-access]
     assert cell.value == "FakeValue"
     assert cell.style == "Normal"
 
@@ -259,7 +259,7 @@ def test_write_cell_with_style(excel_file_handler):
         "Sheet1", position=cell_position, cell_value="FakeValue", style=fake_style
     )  # act
 
-    assert excel_file_handler._get_worksheet("Sheet1")["C2"].style == "fake_style"  # noqa: SLF001
+    assert excel_file_handler._get_worksheet("Sheet1")["C2"].style == "fake_style"  # ruff:ignore[private-member-access]
 
 
 def test_write_cell_with_data_validation(excel_file_handler):

--- a/tests/cli/core/handlers/test_excel_file_manager.py
+++ b/tests/cli/core/handlers/test_excel_file_manager.py
@@ -12,8 +12,8 @@ class FakeExcelFileManager(ExcelFileManager):
 
 def test_write_ids(mocker):
     file_handler_spy = mocker.patch.object(ExcelFileHandler, "write")
-    file_manager = FakeExcelFileManager("/tmp/fake.xlsx")  # noqa: S108
+    file_manager = FakeExcelFileManager("/tmp/fake.xlsx")  # ruff:ignore[hardcoded-temp-file]
 
     file_manager.write_ids({"A1": "12345"})  # act
 
-    file_handler_spy.assert_called_once_with([{file_manager._sheet_name: {"A1": "12345"}}])  # noqa: SLF001
+    file_handler_spy.assert_called_once_with([{file_manager._sheet_name: {"A1": "12345"}}])  # ruff:ignore[private-member-access]

--- a/tests/cli/core/handlers/test_horizontal_tab_file_manager.py
+++ b/tests/cli/core/handlers/test_horizontal_tab_file_manager.py
@@ -174,7 +174,7 @@ def test_create_tab(mocker, fake_horizontal_tab_file_manager):
 
 
 def test_read_data(mocker, fake_horizontal_tab_file_manager):
-    data_model_spy = mocker.spy(fake_horizontal_tab_file_manager._data_model, "from_dict")  # noqa: SLF001
+    data_model_spy = mocker.spy(fake_horizontal_tab_file_manager._data_model, "from_dict")  # ruff:ignore[private-member-access]
 
     result = list(fake_horizontal_tab_file_manager.read_data())
 

--- a/tests/cli/core/handlers/test_vertical_tab_file_manager.py
+++ b/tests/cli/core/handlers/test_vertical_tab_file_manager.py
@@ -110,7 +110,7 @@ def test_read_data(mocker, file_manager):
     get_data_from_vertical_sheet_mock = mocker.patch.object(
         file_manager.file_handler, "get_data_from_vertical_sheet", return_value=mock_data
     )
-    data_model_spy = mocker.spy(file_manager._data_model, "from_dict")  # noqa: SLF001
+    data_model_spy = mocker.spy(file_manager._data_model, "from_dict")  # ruff:ignore[private-member-access]
 
     result = file_manager.read_data()
 

--- a/tests/cli/core/price_lists/handlers/test_price_list_item_excel_file_manager.py
+++ b/tests/cli/core/price_lists/handlers/test_price_list_item_excel_file_manager.py
@@ -11,10 +11,10 @@ from cli.core.price_lists.models import ItemData
 def test_class_properties(mocker, price_list_data_from_dict):
     result = PriceListItemExcelFileManager("fake_file.xlsx")
 
-    assert result._data_model == ItemData  # noqa: SLF001
+    assert result._data_model == ItemData  # ruff:ignore[private-member-access]
     assert result._fields == PRICELIST_ITEMS_FIELDS
-    assert result._sheet_name == TAB_PRICE_ITEMS  # noqa: SLF001
-    assert result._data_validation_map[PRICELIST_ITEMS_ACTION].formula1 == '"-,update"'  # noqa: SLF001
+    assert result._sheet_name == TAB_PRICE_ITEMS  # ruff:ignore[private-member-access]
+    assert result._data_validation_map[PRICELIST_ITEMS_ACTION].formula1 == '"-,update"'  # ruff:ignore[private-member-access]
 
 
 def test_read_data(mocker, item_data_from_dict):
@@ -24,7 +24,7 @@ def test_read_data(mocker, item_data_from_dict):
     )
     excel_manager = PriceListItemExcelFileManager("fake_file.xlsx")
 
-    result = list(excel_manager._read_data())  # noqa: SLF001
+    result = list(excel_manager._read_data())  # ruff:ignore[private-member-access]
 
     assert result == [mock_data]
     get_data_from_horizontal_sheet_mock.assert_called_once_with(


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## Summary

Removes the temporary `RUF105`/`RUF201` entries from `[tool.ruff.lint].ignore` (added to unblock the ruff `0.15.22` bump) and migrates the code to the conventions those preview rules enforce.

Part of epic MPT-23408 / story MPT-23409.

## Changes

- **RUF201** (rule-codes-in-selectors): rule codes → rule names in `lint.select` / `lint.ignore` / `per-file-ignores`.
- **RUF105** (noqa-comments): `# noqa: X` → `# ruff:ignore[X]` (all ruff-only codes).

All migrated via `ruff check --fix` (88 fixes, 0 remaining). flake8 `WPS` suppressions untouched. No behavioural change.

## Validation

`make check-all` fully green — ruff format/check, flake8, mypy, `uv lock --check`, **367 tests passed**.

Jira: MPT-23414


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updates Ruff configuration and suppressions to use Ruff 0.15.22 rule names and `# ruff:ignore[...]` syntax.
- Removes temporary `RUF105` and `RUF201` ignores while preserving flake8 `WPS` suppressions.
- Applies 88 automated fixes with no remaining violations.
- No behavioral changes; `make check-all` passes with 367 tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->