### PR TITLE
MPT-23817 Update mpt-api-client to 6.4.* and migrate to TransportSettings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
         args: ["--config-file=pyproject.toml", "."]
         pass_filenames: false
         additional_dependencies:
-          - mpt-api-client==5.0.*
+          - mpt-api-client==6.4.*
           - pydantic==2.11.*
           - rich==14.3.*
           - types-openpyxl==3.1.*

--- a/cli/core/accounts/app.py
+++ b/cli/core/accounts/app.py
@@ -21,8 +21,7 @@ from cli.core.errors import (
     MPTAPIError,
     NoActiveAccountFoundError,
 )
-from mpt_api_client import MPTClient
-from mpt_api_client.auth import BearerTokenAuthentication
+from cli.core.mpt.mpt_client import create_api_mpt_client
 
 app = typer.Typer()
 accounts_table_renderer = AccountsTableRenderer()
@@ -44,11 +43,7 @@ def add_account(
     """Add an account to work with the SoftwareOne Marketplace."""
     with console.status(STATUS_MSG[READING]) as status:
         status.update(f"{STATUS_MSG[FETCHING]} from environment {environment}")
-        account_service = MPTAccountService(
-            MPTClient.from_config(
-                authentication=BearerTokenAuthentication(secret), base_url=environment
-            )
-        )
+        account_service = MPTAccountService(create_api_mpt_client(secret, environment))
         try:
             token = account_service.get_authentication(secret)
         except (MPTAPIError, ValueError) as error:

--- a/cli/core/mpt/mpt_client.py
+++ b/cli/core/mpt/mpt_client.py
@@ -1,6 +1,28 @@
 from cli.core.accounts.models import Account
-from mpt_api_client import MPTClient
+from mpt_api_client import MPTClient, TransportSettings
 from mpt_api_client.auth import BearerTokenAuthentication
+from mpt_api_client.http import HTTPClient
+
+# Matches the default timeout previously applied by MPTClient.from_config.
+API_REQUEST_TIMEOUT = 60.0
+
+
+def create_api_mpt_client(token: str, environment: str) -> MPTClient:
+    """Create an API client MPTClient instance for the given token and environment.
+
+    Args:
+        token: SoftwareOne Marketplace API token.
+        environment: Protocol and host part of the API URL.
+
+    Returns:
+        An instance of MPTClient to be used for API Client operations.
+    """
+    return MPTClient(
+        HTTPClient(
+            TransportSettings(base_url=environment, timeout=API_REQUEST_TIMEOUT),
+            authentication=BearerTokenAuthentication(token),
+        )
+    )
 
 
 def create_api_mpt_client_from_account(account: Account):
@@ -12,6 +34,4 @@ def create_api_mpt_client_from_account(account: Account):
     Returns:
         An instance of MPTClient to be used for API Client operations.
     """
-    return MPTClient.from_config(
-        authentication=BearerTokenAuthentication(account.token), base_url=account.environment
-    )
+    return create_api_mpt_client(account.token, account.environment)

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -31,7 +31,7 @@ version = "0.1.0"
 requires-python = ">=3.12,<4"
 dependencies = [
   "mpt-cli==2.0.*",
-  "mpt-api-client==5.4.*",
+  "mpt-api-client==6.4.*",
   "typer==0.24.*",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
     "dependency-injector==4.49.*",
-    "mpt-api-client==6.3.*",
+    "mpt-api-client==6.4.*",
     "openpyxl==3.1.*",
     "pydantic==2.13.*",
     "pyfiglet==1.0.*",

--- a/uv.lock
+++ b/uv.lock
@@ -627,15 +627,15 @@ wheels = [
 
 [[package]]
 name = "mpt-api-client"
-version = "6.3.1"
+version = "6.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "httpx-retries" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/f0/6d77d6235801223cfa6a82d13e208469cf12960f4777b841616f64238462/mpt_api_client-6.3.1.tar.gz", hash = "sha256:642f5088c4b2f9608fb70fa9078856423a9096fa118eeede60c6ae9bbb7200f1", size = 65853, upload-time = "2026-06-25T16:05:35.595Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/91/51679b504d7e95c84c8207cdcd7556c6d3daa2174758fefc0ced78a787a6/mpt_api_client-6.4.0.tar.gz", hash = "sha256:d51142471862c0b9faa4339c68b193f2bcf94ae63ce523ed00115d371770be83", size = 67099, upload-time = "2026-07-30T16:38:16.622Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/8d/a3ae1ad7836584e4caacae27816666c55858415f2a80390cefa4264be679/mpt_api_client-6.3.1-py3-none-any.whl", hash = "sha256:87cef1feb7d272dcda619818124605381861a633e442334316181ebb36ba18f7", size = 148484, upload-time = "2026-06-25T16:05:34.462Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/0c/b91b41941c7d9035b6a3cb5dba2279f274a339b3eb470a0cb77a5113bad9/mpt_api_client-6.4.0-py3-none-any.whl", hash = "sha256:6ac8bd1ce5a48cfa3b98ba9e70b40579cca4467a6fa36c502449b16512f1257c", size = 149517, upload-time = "2026-07-30T16:38:15.542Z" },
 ]
 
 [[package]]
@@ -681,7 +681,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "dependency-injector", specifier = "==4.49.*" },
-    { name = "mpt-api-client", specifier = "==6.3.*" },
+    { name = "mpt-api-client", specifier = "==6.4.*" },
     { name = "openpyxl", specifier = "==3.1.*" },
     { name = "pydantic", specifier = "==2.13.*" },
     { name = "pyfiglet", specifier = "==1.0.*" },


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

Updates `mpt-api-client` from `6.3.*` to `6.4.*`, mirroring softwareone-platform/mpt-extension-sdk#270:

- `pyproject.toml`: pin bumped to `mpt-api-client==6.4.*`; `uv.lock` refreshed to 6.4.0.
- `.pre-commit-config.yaml`: mypy hook's `additional_dependencies` pin synced from the stale `5.0.*` to `6.4.*`.
- `docs/plugin-development.md`: stale example pin (`5.4.*`) updated to `6.4.*`.

Also migrates client construction to the 6.4.0 `TransportSettings` API instead of `MPTClient.from_config`:

- `cli/core/mpt/mpt_client.py`: new `create_api_mpt_client(token, environment)` helper builds `MPTClient(HTTPClient(TransportSettings(base_url=..., timeout=60.0), authentication=BearerTokenAuthentication(...)))`, keeping the 60-second timeout `from_config` applied; `create_api_mpt_client_from_account` now delegates to it.
- `cli/core/accounts/app.py`: `add_account` uses the shared helper instead of constructing the client inline.

The removed `ExtensionFrameworkAuthentication`/JWT helpers were never used here, and all other consumers go through `create_api_mpt_client_from_account`, so no further call sites are affected.

## Testing

- `make check` passes (ruff format/check, flake8, mypy, `uv lock --check`).
- `make test` passes: 367 tests, 98% coverage.

## Jira

- [MPT-23817](https://softwareone.atlassian.net/browse/MPT-23817) (subtask of [MPT-23814](https://softwareone.atlassian.net/browse/MPT-23814), relates to MPT-23362)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MPT-23817]: https://softwareone.atlassian.net/browse/MPT-23817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-23817](https://softwareone.atlassian.net/browse/MPT-23817)

- Updates `mpt-api-client` from 6.3.x to 6.4.x across `pyproject.toml`, `uv.lock`, `.pre-commit-config.yaml` (mypy hook), and `docs/plugin-development.md`.
- Refactors MPT client construction to centralize setup in a new `create_api_mpt_client` helper using `BearerTokenAuthentication`, `TransportSettings`, and `HTTPClient`, preserving the 60-second timeout.
- Verification: `make check` / `make test` pass (367 tests, 98% coverage).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->