### PR TITLE
MPT-24655 Keep .xlsx extension on the price list export temp file

### DIFF
--- a/cli/core/price_lists/app/export.py
+++ b/cli/core/price_lists/app/export.py
@@ -60,7 +60,7 @@ class PriceListExporter:
                 abort=True,
             )
 
-        temp_path = file_path.with_name(f"{file_path.name}.tmp")
+        temp_path = file_path.with_name(f"{file_path.stem}.tmp.xlsx")
         temp_path.unlink(missing_ok=True)
         if not self._export_workbook(price_list_id, temp_path):
             return False

--- a/tests/cli/core/price_lists/app/test_export.py
+++ b/tests/cli/core/price_lists/app/test_export.py
@@ -1,6 +1,7 @@
 import re
 
 from cli.core.price_lists import app
+from cli.core.price_lists.app import export as app_export
 from cli.core.price_lists.services import ItemService, PriceListService
 from cli.core.services.service_result import ServiceResult
 from cli.core.stats import PriceListStatsCollector
@@ -70,6 +71,30 @@ def test_export_price_list(mocker, active_operations_account, price_list_data_fr
     replace_mock.assert_called_once()
     price_list_service_export_mock.assert_called_once()
     item_service_export_mock.assert_called_once()
+
+
+def test_export_temp_file_keeps_xlsx_extension(
+    mocker, active_operations_account, price_list_data_from_json
+):
+    mocker.patch("pathlib.Path.unlink", autospec=True)
+    replace_mock = mocker.patch("pathlib.Path.replace", autospec=True)
+    stats = PriceListStatsCollector()
+    file_manager_spy = mocker.spy(app_export, "PriceListExcelFileManager")
+    mocker.patch(
+        "cli.core.price_lists.services.PriceListService.export",
+        return_value=ServiceResult(success=True, model=price_list_data_from_json, stats=stats),
+    )
+    mocker.patch(
+        "cli.core.price_lists.services.ItemService.export",
+        return_value=ServiceResult(success=True, model=None, stats=stats),
+    )
+
+    result = runner.invoke(app, ["export", "PRC-1234-1234-1234"], input="y\n")
+
+    assert result.exit_code == 0
+    temp_path = replace_mock.call_args.args[0]
+    assert (temp_path.suffix, temp_path.name) == (".xlsx", "PRC-1234-1234-1234.tmp.xlsx")
+    assert file_manager_spy.call_args.args == (str(temp_path),)
 
 
 def test_export_price_list_item_no_success(


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

Fixes [MPT-24655](https://softwareone.atlassian.net/browse/MPT-24655): every `mpt-cli pricelists export` run crashed with `InvalidFileException`.

`PriceListExporter.export_one` writes the workbook to a temporary file before renaming it to the final `<pricelist-id>.xlsx`. The temp file was named `<pricelist-id>.xlsx.tmp`, and when the item-export stage reopened it, openpyxl rejected the `.tmp` extension (`openpyxl does not support .tmp file format`), aborting the export and leaving the stale temp file behind.

- Name the temp file `<pricelist-id>.tmp.xlsx` so openpyxl can reopen it; the rename-on-success behavior is unchanged.
- Add a regression test asserting the temp file keeps the `.xlsx` extension and is the path handed to the file managers.

## Testing

- `make check` — ruff, flake8, mypy, uv lock: all pass.
- `make test tests/cli/core/price_lists/app/test_export.py` — 7 passed (includes the new regression test).
- Verified manually in Docker against the test environment: `mpt-cli pricelists export PRC-6790-8707-0001` now produces `PRC-6790-8707-0001.xlsx`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updates price list export temporary files to use the `<price-list-id>.tmp.xlsx` pattern.
- Keeps the `.xlsx` extension so `openpyxl` can reopen the file during item export.
- Adds a regression test for the temporary filename and file manager path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-24655]: https://softwareone.atlassian.net/browse/MPT-24655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ